### PR TITLE
Commissioning Complete from iOS

### DIFF
--- a/matter/src/data_model/sdm/noc.rs
+++ b/matter/src/data_model/sdm/noc.rs
@@ -141,8 +141,13 @@ impl NocCluster {
 
         let noc_value = Cert::new(r.noc_value.0).map_err(|_| NocStatus::InvalidNOC)?;
         info!("Received NOC as: {}", noc_value);
-        let icac_value = Cert::new(r.icac_value.0).map_err(|_| NocStatus::InvalidNOC)?;
-        info!("Received ICAC as: {}", icac_value);
+        let icac_value = if r.icac_value.0.len() != 0 {
+            let cert = Cert::new(r.icac_value.0).map_err(|_| NocStatus::InvalidNOC)?;
+            info!("Received ICAC as: {}", cert);
+            Some(cert)
+        } else {
+            None
+        };
 
         let fabric = Fabric::new(
             noc_data.key_pair,

--- a/matter/src/data_model/sdm/nw_commissioning.rs
+++ b/matter/src/data_model/sdm/nw_commissioning.rs
@@ -36,9 +36,9 @@ impl ClusterType for NwCommCluster {
 }
 
 enum FeatureMap {
-    _Wifi = 0,
-    _Thread = 1,
-    Ethernet = 2,
+    _Wifi = 0x01,
+    _Thread = 0x02,
+    Ethernet = 0x04,
 }
 
 impl NwCommCluster {

--- a/matter/src/data_model/system_model/descriptor.rs
+++ b/matter/src/data_model/system_model/descriptor.rs
@@ -48,6 +48,7 @@ impl DescriptorCluster {
             base: Cluster::new(ID)?,
         });
         c.base.add_attribute(attr_serverlist_new()?)?;
+        c.base.add_attribute(attr_partslist_new()?)?;
         Ok(c)
     }
 
@@ -65,6 +66,12 @@ impl DescriptorCluster {
         });
         let _ = tw.end_container();
     }
+
+    fn encode_parts_list(&self, tag: TagType, tw: &mut TLVWriter) {
+        // TODO: Support Partslist
+        let _ = tw.start_array(tag);
+        let _ = tw.end_container();
+    }
 }
 
 impl ClusterType for DescriptorCluster {
@@ -80,7 +87,9 @@ impl ClusterType for DescriptorCluster {
             Some(Attributes::ServerList) => encoder.encode(EncodeValue::Closure(&|tag, tw| {
                 self.encode_server_list(tag, tw)
             })),
-
+            Some(Attributes::PartsList) => encoder.encode(EncodeValue::Closure(&|tag, tw| {
+                self.encode_parts_list(tag, tw)
+            })),
             _ => {
                 error!("Attribute not supported: this shouldn't happen");
             }
@@ -91,6 +100,15 @@ impl ClusterType for DescriptorCluster {
 fn attr_serverlist_new() -> Result<Attribute, Error> {
     Attribute::new(
         Attributes::ServerList as u16,
+        AttrValue::Custom,
+        Access::RV,
+        Quality::NONE,
+    )
+}
+
+fn attr_partslist_new() -> Result<Attribute, Error> {
+    Attribute::new(
+        Attributes::PartsList as u16,
         AttrValue::Custom,
         Access::RV,
         Quality::NONE,

--- a/matter/src/secure_channel/case.rs
+++ b/matter/src/secure_channel/case.rs
@@ -475,7 +475,10 @@ impl Case {
         let mut tw = TLVWriter::new(&mut write_buf);
         tw.start_struct(TagType::Anonymous)?;
         tw.str16_as(TagType::Context(1), |buf| fabric.noc.as_tlv(buf))?;
-        tw.str16_as(TagType::Context(2), |buf| fabric.icac.as_tlv(buf))?;
+        if let Some(icac_cert) = &fabric.icac {
+            tw.str16_as(TagType::Context(2), |buf| icac_cert.as_tlv(buf))?
+        };
+
         tw.str8(TagType::Context(3), signature)?;
         tw.str8(TagType::Context(4), &resumption_id)?;
         tw.end_container()?;
@@ -515,7 +518,9 @@ impl Case {
         let mut tw = TLVWriter::new(&mut write_buf);
         tw.start_struct(TagType::Anonymous)?;
         tw.str16_as(TagType::Context(1), |buf| fabric.noc.as_tlv(buf))?;
-        tw.str16_as(TagType::Context(2), |buf| fabric.icac.as_tlv(buf))?;
+        if let Some(icac_cert) = &fabric.icac {
+            tw.str16_as(TagType::Context(2), |buf| icac_cert.as_tlv(buf))?;
+        }
         tw.str8(TagType::Context(3), our_pub_key)?;
         tw.str8(TagType::Context(4), peer_pub_key)?;
         tw.end_container()?;

--- a/matter/src/tlv/writer.rs
+++ b/matter/src/tlv/writer.rs
@@ -130,7 +130,7 @@ impl<'a, 'b> TLVWriter<'a, 'b> {
 
     pub fn str8(&mut self, tag_type: TagType, data: &[u8]) -> Result<(), Error> {
         if data.len() > 256 {
-            error!("use put_str16() instead");
+            error!("use str16() instead");
             return Err(Error::Invalid);
         }
         self.put_control_tag(tag_type, WriteElementType::Str8l)?;


### PR DESCRIPTION
Changes to get 'Commissioning Complete' from iOS
* ICAC is optional and needs to be handled accordingly for both AddNOC case, and the case where the initiator's ICAC is also optional
* Fix incorrect transport mapping in Network Commissioning Cluster
* Placeholder for PartsList Attribute in Descriptor Cluster

While we get commissioning complete with these changes, the 'Add Accessory' path isn't fully functional on iOS yet, because once commissioning is performed, there are a few read and timed requests that aren't supported yet. This will happen in follow-on requests.