### PR TITLE
Add tests for timed requests

### DIFF
--- a/matter/src/interaction_model/core.rs
+++ b/matter/src/interaction_model/core.rs
@@ -44,7 +44,7 @@ use super::{messages::msg::TimedReq, InteractionConsumer};
 /* Interaction Model ID as per the Matter Spec */
 const PROTO_ID_INTERACTION_MODEL: usize = 0x01;
 
-#[derive(FromPrimitive, Debug, Copy, Clone)]
+#[derive(FromPrimitive, Debug, Copy, Clone, PartialEq)]
 pub enum OpCode {
     Reserved = 0,
     StatusResponse = 1,

--- a/matter/src/interaction_model/messages.rs
+++ b/matter/src/interaction_model/messages.rs
@@ -73,12 +73,12 @@ pub mod msg {
 
     use super::ib::{AttrData, AttrPath, AttrResp, CmdData, DataVersionFilter};
 
-    #[derive(FromTLV)]
+    #[derive(FromTLV, ToTLV)]
     pub struct TimedReq {
         pub timeout: u16,
     }
 
-    #[derive(ToTLV)]
+    #[derive(FromTLV, ToTLV)]
     pub struct StatusResp {
         pub status: IMStatusCode,
     }

--- a/matter/src/interaction_model/messages.rs
+++ b/matter/src/interaction_model/messages.rs
@@ -83,7 +83,7 @@ pub mod msg {
         pub status: IMStatusCode,
     }
 
-    #[derive(FromTLV)]
+    #[derive(FromTLV, ToTLV)]
     #[tlvargs(lifetime = "'a")]
     pub struct InvReq<'a> {
         pub suppress_response: Option<bool>,

--- a/matter/tests/common/attributes.rs
+++ b/matter/tests/common/attributes.rs
@@ -21,6 +21,7 @@ use matter::interaction_model::{messages::ib::AttrResp, messages::msg::ReportDat
 pub fn assert_attr_report(received: &ReportDataMsg, expected: &[AttrResp]) {
     let mut index = 0;
 
+    // We can't use assert_eq because it will also try to match data-version
     for inv_response in received.attr_reports.as_ref().unwrap().iter() {
         println!("Validating index {}", index);
         match expected[index] {
@@ -34,14 +35,7 @@ pub fn assert_attr_report(received: &ReportDataMsg, expected: &[AttrResp]) {
                     panic!("Invalid response, expected AttrRespIn::Data");
                 }
             },
-            AttrResp::Status(e_s) => match inv_response {
-                AttrResp::Status(s) => {
-                    assert_eq!(e_s, s);
-                }
-                _ => {
-                    panic!("Invalid response, expected AttrRespIn::Status");
-                }
-            },
+            AttrResp::Status(s) => assert_eq!(AttrResp::Status(s), inv_response),
         }
         println!("Index {} success", index);
         index += 1;

--- a/matter/tests/common/commands.rs
+++ b/matter/tests/common/commands.rs
@@ -1,0 +1,98 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+use matter::{
+    data_model::objects::EncodeValue,
+    interaction_model::{
+        messages::ib::{CmdPath, CmdStatus, InvResp},
+        messages::msg,
+    },
+};
+
+pub enum ExpectedInvResp {
+    Cmd(CmdPath, u8),
+    Status(CmdStatus),
+}
+
+pub fn assert_inv_response(resp: &msg::InvResp, expected: &[ExpectedInvResp]) {
+    let mut index = 0;
+    for inv_response in resp.inv_responses.unwrap().iter() {
+        println!("Validating index {}", index);
+        match expected[index] {
+            ExpectedInvResp::Cmd(e_c, e_d) => match inv_response {
+                InvResp::Cmd(c) => {
+                    assert_eq!(e_c, c.path);
+                    match c.data {
+                        EncodeValue::Tlv(t) => {
+                            assert_eq!(e_d, t.find_tag(0).unwrap().u8().unwrap())
+                        }
+                        _ => panic!("Incorrect CmdDataType"),
+                    }
+                }
+                _ => {
+                    panic!("Invalid response, expected InvResponse::Cmd");
+                }
+            },
+            ExpectedInvResp::Status(e_status) => match inv_response {
+                InvResp::Status(status) => {
+                    assert_eq!(e_status, status);
+                }
+                _ => {
+                    panic!("Invalid response, expected InvResponse::Status");
+                }
+            },
+        }
+        println!("Index {} success", index);
+        index += 1;
+    }
+    assert_eq!(index, expected.len());
+}
+
+#[macro_export]
+macro_rules! cmd_data {
+    ($path:ident, $data:literal) => {
+        CmdData::new($path, EncodeValue::Value(&($data as u32)))
+    };
+}
+
+#[macro_export]
+macro_rules! echo_req {
+    ($endpoint:literal, $data:literal) => {
+        CmdData::new(
+            CmdPath::new(
+                Some($endpoint),
+                Some(echo_cluster::ID),
+                Some(echo_cluster::Commands::EchoReq as u16),
+            ),
+            EncodeValue::Value(&($data as u32)),
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! echo_resp {
+    ($endpoint:literal, $data:literal) => {
+        ExpectedInvResp::Cmd(
+            CmdPath::new(
+                Some($endpoint),
+                Some(echo_cluster::ID),
+                Some(echo_cluster::Commands::EchoResp as u16),
+            ),
+            $data,
+        )
+    };
+}

--- a/matter/tests/common/mod.rs
+++ b/matter/tests/common/mod.rs
@@ -16,5 +16,6 @@
  */
 
 pub mod attributes;
+pub mod commands;
 pub mod echo_cluster;
 pub mod im_engine;

--- a/matter/tests/data_model/acl_and_dataver.rs
+++ b/matter/tests/data_model/acl_and_dataver.rs
@@ -29,8 +29,7 @@ use matter::{
         },
         messages::{msg, GenericPath},
     },
-    tlv::{self, ElementType, FromTLV, TLVArray, TLVElement, TLVWriter, TagType, ToTLV},
-    utils::writebuf::WriteBuf,
+    tlv::{self, ElementType, FromTLV, TLVArray, TLVElement, TLVWriter, TagType},
 };
 
 use crate::{
@@ -61,16 +60,10 @@ fn gen_read_reqs_output<'a>(
     dataver_filters: Option<TLVArray<'a, DataVersionFilter>>,
     out_buf: &'a mut [u8],
 ) -> ReportDataMsg<'a> {
-    let mut buf = [0u8; 400];
-    let buf_len = buf.len();
-    let mut wb = WriteBuf::new(&mut buf, buf_len);
-    let mut tw = TLVWriter::new(&mut wb);
-
     let mut read_req = ReadReq::new(true).set_attr_requests(input);
     read_req.dataver_filters = dataver_filters;
-    read_req.to_tlv(&mut tw, TagType::Anonymous).unwrap();
 
-    let mut input = ImInput::new(OpCode::ReadRequest, wb.as_borrow_slice());
+    let mut input = ImInput::new(OpCode::ReadRequest, &read_req);
     input.set_peer_node_id(peer_node_id);
 
     let (_, out_buf) = im.process(&input, out_buf);
@@ -87,17 +80,10 @@ fn handle_write_reqs(
     input: &[AttrData],
     expected: &[AttrStatus],
 ) {
-    let mut buf = [0u8; 400];
     let mut out_buf = [0u8; 400];
-
-    let buf_len = buf.len();
-    let mut wb = WriteBuf::new(&mut buf, buf_len);
-    let mut tw = TLVWriter::new(&mut wb);
-
     let write_req = WriteReq::new(false, input);
-    write_req.to_tlv(&mut tw, TagType::Anonymous).unwrap();
 
-    let mut input = ImInput::new(OpCode::WriteRequest, wb.as_borrow_slice());
+    let mut input = ImInput::new(OpCode::WriteRequest, &write_req);
     input.set_peer_node_id(peer_node_id);
     let (_, out_buf) = im.process(&input, &mut out_buf);
 

--- a/matter/tests/data_model/acl_and_dataver.rs
+++ b/matter/tests/data_model/acl_and_dataver.rs
@@ -73,8 +73,7 @@ fn gen_read_reqs_output<'a>(
     let mut input = ImInput::new(OpCode::ReadRequest, wb.as_borrow_slice());
     input.set_peer_node_id(peer_node_id);
 
-    let out_buf_len = im.process(&input, out_buf);
-    let out_buf = &out_buf[..out_buf_len];
+    let (_, out_buf) = im.process(&input, out_buf);
 
     tlv::print_tlv_list(out_buf);
     let root = tlv::get_root_node_struct(out_buf).unwrap();
@@ -100,9 +99,8 @@ fn handle_write_reqs(
 
     let mut input = ImInput::new(OpCode::WriteRequest, wb.as_borrow_slice());
     input.set_peer_node_id(peer_node_id);
-    let out_buf_len = im.process(&input, &mut out_buf);
+    let (_, out_buf) = im.process(&input, &mut out_buf);
 
-    let out_buf = &out_buf[..out_buf_len];
     tlv::print_tlv_list(out_buf);
     let root = tlv::get_root_node_struct(out_buf).unwrap();
 

--- a/matter/tests/data_model/attribute_lists.rs
+++ b/matter/tests/data_model/attribute_lists.rs
@@ -19,14 +19,13 @@ use matter::{
     data_model::{core::DataModel, objects::EncodeValue},
     interaction_model::{
         core::{IMStatusCode, OpCode},
+        messages::GenericPath,
         messages::{
             ib::{AttrData, AttrPath, AttrStatus},
-            msg::WriteReq,
+            msg::{WriteReq, WriteResp},
         },
-        messages::{msg, GenericPath},
     },
-    tlv::{self, FromTLV, Nullable, TLVWriter, TagType, ToTLV},
-    utils::writebuf::WriteBuf,
+    tlv::{self, FromTLV, Nullable},
 };
 
 use crate::common::{
@@ -36,36 +35,14 @@ use crate::common::{
 
 // Helper for handling Write Attribute sequences
 fn handle_write_reqs(input: &[AttrData], expected: &[AttrStatus]) -> DataModel {
-    let mut buf = [0u8; 400];
     let mut out_buf = [0u8; 400];
-
-    let buf_len = buf.len();
-    let mut wb = WriteBuf::new(&mut buf, buf_len);
-    let mut tw = TLVWriter::new(&mut wb);
-
     let write_req = WriteReq::new(false, input);
-    write_req.to_tlv(&mut tw, TagType::Anonymous).unwrap();
 
-    let (dm, _, out_buf) = im_engine(OpCode::WriteRequest, wb.as_borrow_slice(), &mut out_buf);
+    let (dm, _, out_buf) = im_engine(OpCode::WriteRequest, &write_req, &mut out_buf);
     tlv::print_tlv_list(out_buf);
     let root = tlv::get_root_node_struct(out_buf).unwrap();
-
-    let mut index = 0;
-    let response_iter = root
-        .find_tag(msg::WriteRespTag::WriteResponses as u32)
-        .unwrap()
-        .confirm_array()
-        .unwrap()
-        .enter()
-        .unwrap();
-    for response in response_iter {
-        println!("Validating index {}", index);
-        let status = AttrStatus::from_tlv(&response).unwrap();
-        assert_eq!(expected[index], status);
-        println!("Index {} success", index);
-        index += 1;
-    }
-    assert_eq!(index, expected.len());
+    let resp = WriteResp::from_tlv(&root).unwrap();
+    assert_eq!(resp.write_responses, expected);
     dm
 }
 

--- a/matter/tests/data_model/attribute_lists.rs
+++ b/matter/tests/data_model/attribute_lists.rs
@@ -46,8 +46,7 @@ fn handle_write_reqs(input: &[AttrData], expected: &[AttrStatus]) -> DataModel {
     let write_req = WriteReq::new(false, input);
     write_req.to_tlv(&mut tw, TagType::Anonymous).unwrap();
 
-    let (dm, out_buf_len) = im_engine(OpCode::WriteRequest, wb.as_borrow_slice(), &mut out_buf);
-    let out_buf = &out_buf[..out_buf_len];
+    let (dm, _, out_buf) = im_engine(OpCode::WriteRequest, wb.as_borrow_slice(), &mut out_buf);
     tlv::print_tlv_list(out_buf);
     let root = tlv::get_root_node_struct(out_buf).unwrap();
 

--- a/matter/tests/data_model/attributes.rs
+++ b/matter/tests/data_model/attributes.rs
@@ -54,8 +54,7 @@ fn gen_read_reqs_output<'a>(input: &[AttrPath], out_buf: &'a mut [u8]) -> Report
     let read_req = ReadReq::new(true).set_attr_requests(input);
     read_req.to_tlv(&mut tw, TagType::Anonymous).unwrap();
 
-    let (_, out_buf_len) = im_engine(OpCode::ReadRequest, wb.as_borrow_slice(), out_buf);
-    let out_buf = &out_buf[..out_buf_len];
+    let (_, _, out_buf) = im_engine(OpCode::ReadRequest, wb.as_borrow_slice(), out_buf);
     tlv::print_tlv_list(out_buf);
     let root = tlv::get_root_node_struct(out_buf).unwrap();
     ReportDataMsg::from_tlv(&root).unwrap()
@@ -73,12 +72,12 @@ fn handle_write_reqs(input: &[AttrData], expected: &[AttrStatus]) -> DataModel {
     let write_req = WriteReq::new(false, input);
     write_req.to_tlv(&mut tw, TagType::Anonymous).unwrap();
 
-    let (dm, out_buf_len) = im_engine(OpCode::WriteRequest, wb.as_borrow_slice(), &mut out_buf);
-    let out_buf = &out_buf[..out_buf_len];
+    let (dm, _, out_buf) = im_engine(OpCode::WriteRequest, wb.as_borrow_slice(), &mut out_buf);
     tlv::print_tlv_list(out_buf);
     let root = tlv::get_root_node_struct(out_buf).unwrap();
 
     let mut index = 0;
+
     let response_iter = root
         .find_tag(msg::WriteRespTag::WriteResponses as u32)
         .unwrap()

--- a/matter/tests/data_model/commands.rs
+++ b/matter/tests/data_model/commands.rs
@@ -56,17 +56,10 @@ fn handle_commands(input: &[CmdData], expected: &[ExpectedInvResp]) {
     tlv::print_tlv_list(out_buf);
     let root = tlv::get_root_node_struct(out_buf).unwrap();
 
+    let resp = msg::InvResp::from_tlv(&root).unwrap();
     let mut index = 0;
-    let cmd_list_iter = root
-        .find_tag(msg::InvRespTag::InvokeResponses as u32)
-        .unwrap()
-        .confirm_array()
-        .unwrap()
-        .enter()
-        .unwrap();
-    for response in cmd_list_iter {
+    for inv_response in resp.inv_responses.unwrap().iter() {
         println!("Validating index {}", index);
-        let inv_response = InvResp::from_tlv(&response).unwrap();
         match expected[index] {
             ExpectedInvResp::Cmd(e_c, e_d) => match inv_response {
                 InvResp::Cmd(c) => {

--- a/matter/tests/data_model/commands.rs
+++ b/matter/tests/data_model/commands.rs
@@ -47,8 +47,7 @@ fn handle_commands(input: &[(CmdPath, Option<u8>)], expected: &[ExpectedInvResp]
 
     td.commands(input).unwrap();
 
-    let (_, out_buf_len) = im_engine(OpCode::InvokeRequest, wb.as_borrow_slice(), &mut out_buf);
-    let out_buf = &out_buf[..out_buf_len];
+    let (_, _, out_buf) = im_engine(OpCode::InvokeRequest, wb.as_borrow_slice(), &mut out_buf);
     tlv::print_tlv_list(out_buf);
     let root = tlv::get_root_node_struct(out_buf).unwrap();
 

--- a/matter/tests/data_model/commands.rs
+++ b/matter/tests/data_model/commands.rs
@@ -25,8 +25,7 @@ use matter::{
             msg::InvReq,
         },
     },
-    tlv::{self, FromTLV, TLVArray, TLVWriter, TagType, ToTLV},
-    utils::writebuf::WriteBuf,
+    tlv::{self, FromTLV, TLVArray},
 };
 
 use crate::common::{echo_cluster, im_engine::im_engine};
@@ -38,21 +37,14 @@ enum ExpectedInvResp {
 
 // Helper for handling Invoke Command sequences
 fn handle_commands(input: &[CmdData], expected: &[ExpectedInvResp]) {
-    let mut buf = [0u8; 400];
     let mut out_buf = [0u8; 400];
-
-    let buf_len = buf.len();
-    let mut wb = WriteBuf::new(&mut buf, buf_len);
-    let mut tw = TLVWriter::new(&mut wb);
-
     let req = InvReq {
         suppress_response: Some(false),
         timed_request: Some(false),
         inv_requests: Some(TLVArray::Slice(input)),
     };
-    req.to_tlv(&mut tw, TagType::Anonymous).unwrap();
 
-    let (_, _, out_buf) = im_engine(OpCode::InvokeRequest, wb.as_borrow_slice(), &mut out_buf);
+    let (_, _, out_buf) = im_engine(OpCode::InvokeRequest, &req, &mut out_buf);
     tlv::print_tlv_list(out_buf);
     let root = tlv::get_root_node_struct(out_buf).unwrap();
 

--- a/matter/tests/data_model/timed_requests.rs
+++ b/matter/tests/data_model/timed_requests.rs
@@ -1,0 +1,185 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+use core::time;
+use std::thread;
+
+use matter::{
+    data_model::{
+        core::DataModel,
+        objects::{AttrValue, EncodeValue},
+    },
+    interaction_model::{
+        core::{IMStatusCode, OpCode},
+        messages::{
+            ib::{AttrData, AttrPath, AttrStatus},
+            msg::{StatusResp, TimedReq, WriteReq},
+        },
+        messages::{msg, GenericPath},
+    },
+    tlv::{self, FromTLV, TLVWriter, TagType, ToTLV},
+    transport::exchange::{self, Exchange},
+    utils::writebuf::WriteBuf,
+};
+
+use crate::common::{
+    echo_cluster,
+    im_engine::{ImEngine, ImInput},
+};
+
+enum WriteResponse<'a> {
+    TransactionError,
+    TransactionSuccess(&'a [AttrStatus]),
+}
+
+// Helper for handling Write Attribute sequences
+fn handle_timed_write_reqs(
+    input: &[AttrData],
+    expected: WriteResponse,
+    timeout: u16,
+    delay: u16,
+) -> DataModel {
+    let mut buf = [0u8; 400];
+    let buf_len = buf.len();
+
+    let mut im_engine = ImEngine::new();
+    // Use the same exchange for all parts of the transaction
+    im_engine.exch = Some(Exchange::new(1, 0, exchange::Role::Responder));
+
+    // Send Timed Req
+    let mut out_buf = [0u8; 400];
+    let mut wb = WriteBuf::new(&mut buf, buf_len);
+    let mut tw = TLVWriter::new(&mut wb);
+    let timed_req = TimedReq { timeout };
+    timed_req.to_tlv(&mut tw, TagType::Anonymous).unwrap();
+    let im_input = ImInput::new(OpCode::TimedRequest, wb.as_borrow_slice());
+    let (_, out_buf) = im_engine.process(&im_input, &mut out_buf);
+    tlv::print_tlv_list(out_buf);
+
+    // Process any delays
+    let delay = time::Duration::from_millis(delay.into());
+    thread::sleep(delay);
+
+    // Send Write Req
+    let mut out_buf = [0u8; 400];
+    let mut wb = WriteBuf::new(&mut buf, buf_len);
+    let mut tw = TLVWriter::new(&mut wb);
+    let write_req = WriteReq::new(false, input);
+    write_req.to_tlv(&mut tw, TagType::Anonymous).unwrap();
+    let input = ImInput::new(OpCode::WriteRequest, wb.as_borrow_slice());
+    let (resp_opcode, out_buf) = im_engine.process(&input, &mut out_buf);
+
+    tlv::print_tlv_list(out_buf);
+    let root = tlv::get_root_node_struct(out_buf).unwrap();
+
+    let mut index = 0;
+
+    match expected {
+        WriteResponse::TransactionSuccess(t) => {
+            assert_eq!(
+                num::FromPrimitive::from_u8(resp_opcode),
+                Some(OpCode::WriteResponse)
+            );
+            let response_iter = root
+                .find_tag(msg::WriteRespTag::WriteResponses as u32)
+                .unwrap()
+                .confirm_array()
+                .unwrap()
+                .enter()
+                .unwrap();
+            for response in response_iter {
+                println!("Validating index {}", index);
+                let status = AttrStatus::from_tlv(&response).unwrap();
+                assert_eq!(t[index], status);
+                println!("Index {} success", index);
+                index += 1;
+            }
+            assert_eq!(index, t.len());
+        }
+        WriteResponse::TransactionError => {
+            assert_eq!(
+                num::FromPrimitive::from_u8(resp_opcode),
+                Some(OpCode::StatusResponse)
+            );
+            let status_resp = StatusResp::from_tlv(&root).unwrap();
+            assert_eq!(status_resp.status, IMStatusCode::Timeout);
+        }
+    }
+    im_engine.dm
+}
+
+#[test]
+fn test_timed_write_fail_and_success() {
+    // - 1 Timed Attr Write Transaction should fail due to timeout
+    // - 1 Timed Attr Write Transaction should succeed
+    let val0 = 10;
+    let _ = env_logger::try_init();
+    let attr_data0 = |tag, t: &mut TLVWriter| {
+        let _ = t.u16(tag, val0);
+    };
+
+    let ep_att = GenericPath::new(
+        None,
+        Some(echo_cluster::ID),
+        Some(echo_cluster::Attributes::AttWrite as u32),
+    );
+    let input = &[AttrData::new(
+        None,
+        AttrPath::new(&ep_att),
+        EncodeValue::Closure(&attr_data0),
+    )];
+
+    let ep0_att = GenericPath::new(
+        Some(0),
+        Some(echo_cluster::ID),
+        Some(echo_cluster::Attributes::AttWrite as u32),
+    );
+
+    let ep1_att = GenericPath::new(
+        Some(1),
+        Some(echo_cluster::ID),
+        Some(echo_cluster::Attributes::AttWrite as u32),
+    );
+    let expected = &[
+        AttrStatus::new(&ep0_att, IMStatusCode::Sucess, 0),
+        AttrStatus::new(&ep1_att, IMStatusCode::Sucess, 0),
+    ];
+
+    // Test with incorrect handling
+    handle_timed_write_reqs(input, WriteResponse::TransactionError, 400, 500);
+
+    // Test with correct handling
+    let dm = handle_timed_write_reqs(input, WriteResponse::TransactionSuccess(expected), 400, 0);
+    assert_eq!(
+        AttrValue::Uint16(val0),
+        dm.read_attribute_raw(
+            0,
+            echo_cluster::ID,
+            echo_cluster::Attributes::AttWrite as u16
+        )
+        .unwrap()
+    );
+    assert_eq!(
+        AttrValue::Uint16(val0),
+        dm.read_attribute_raw(
+            0,
+            echo_cluster::ID,
+            echo_cluster::Attributes::AttWrite as u16
+        )
+        .unwrap()
+    );
+}

--- a/matter/tests/data_model_tests.rs
+++ b/matter/tests/data_model_tests.rs
@@ -22,4 +22,5 @@ mod data_model {
     mod attribute_lists;
     mod attributes;
     mod commands;
+    mod timed_requests;
 }


### PR DESCRIPTION
* Simplification of the test cases that benefits from the latest ToTLV/FromTLV proc macros
* Addition of test cases for timed write and timed invoke requests