### PR TITLE
Cargo restructure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = ["matter", "matter_macro_derive", "boxslab"]
+
+exclude = ["examples/*"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
-members = ["matter", "matter_macro_derive", "boxslab"]
+members = ["matter", "matter_macro_derive", "boxslab", "tools/tlv_tool"]
 
 exclude = ["examples/*"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-
 # matter-rs: The Rust Implementation of Matter
 
 ![experimental](https://img.shields.io/badge/status-Experimental-red) [![license](https://img.shields.io/badge/license-Apache2-green.svg)](https://raw.githubusercontent.com/project-chip/matter-rs/main/LICENSE)
-
-
 
 [![Test Linux (OpenSSL)](https://github.com/project-chip/matter-rs/actions/workflows/test-linux-openssl.yml/badge.svg)](https://github.com/project-chip/matter-rs/actions/workflows/test-linux-openssl.yml)
 [![Test Linux (mbedTLS)](https://github.com/project-chip/matter-rs/actions/workflows/test-linux-mbedtls.yml/badge.svg)](https://github.com/project-chip/matter-rs/actions/workflows/test-linux-mbedtls.yml)
@@ -11,23 +8,31 @@
 ## Build
 
 Building the library:
+
 ```
-$ cd matter
 $ cargo build
 ```
 
 Building the example:
+
 ```
-$ cd matter
 $ RUST_LOG="matter" cargo run --example onoff_light
 ```
 
 With the chip-tool (the current tool for testing Matter) use the Ethernet commissioning mechanism:
+
+```
+$ chip-tool pairing code 12344321 <Pairing-Code>
+```
+
+Or alternatively:
+
 ```
 $ chip-tool pairing ethernet 12344321 123456 0 <IP-Address> 5540
 ```
 
 Interact with the device
+
 ```
 # Read server-list
 $ chip-tool descriptor read server-list 12344321 0
@@ -40,6 +45,7 @@ $ chip-tool onoff on 12344321 1
 ```
 
 ## Functionality
+
 - Secure Channel:
   - PASE
   - CASE
@@ -55,4 +61,3 @@ $ chip-tool onoff on 12344321 1
 ## Notes
 
 The matter-rs project is a work-in-progress and does NOT yet fully implement Matter.
-

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = ["*"]
+exclude = ["target", ".cargo"]
+resolver = "2"

--- a/matter/Cargo.toml
+++ b/matter/Cargo.toml
@@ -35,7 +35,7 @@ env_logger = "0.10.0"
 rand = "0.8.5"
 esp-idf-sys = { version = "0.32", features = ["binstart"], optional = true }
 openssl = { git = "https://github.com/sfackler/rust-openssl", optional = true }
-foreign-types = { version = "0.4.0", optional = true }
+foreign-types = { version = "0.3.2", optional = true }
 sha2 = { version = "0.9.9", optional = true }
 hmac = { version = "0.11.0", optional = true }
 mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", optional = true }

--- a/matter/Cargo.toml
+++ b/matter/Cargo.toml
@@ -36,7 +36,7 @@ rand = "0.8.5"
 esp-idf-sys = { version = "0.32", features = ["binstart"], optional = true }
 openssl = { git = "https://github.com/sfackler/rust-openssl", optional = true }
 foreign-types = { version = "0.4.0", optional = true }
-sha2 = { version = "0.10.6", optional = true }
+sha2 = { version = "0.9.9", optional = true }
 hmac = { version = "0.11.0", optional = true }
 mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", optional = true }
 subtle = "2.4.1"

--- a/matter/Cargo.toml
+++ b/matter/Cargo.toml
@@ -21,31 +21,31 @@ crypto_mbedtls = ["mbedtls"]
 crypto_esp_mbedtls = ["esp-idf-sys"]
 
 [dependencies]
-boxslab = { path = "../boxslab"}
-matter_macro_derive = { path = "../matter_macro_derive"}
+boxslab = { path = "../boxslab" }
+matter_macro_derive = { path = "../matter_macro_derive" }
 bitflags = "1.3"
 byteorder = "1.4.3"
-heapless = {version = "0.7.7", features = ["x86-sync-pool"] }
-generic-array = "0.14.5"
-num = "0.3"
+heapless = { version = "0.7.16", features = ["x86-sync-pool"] }
+generic-array = "0.14.6"
+num = "0.4"
 num-derive = "0.3.3"
-num-traits = "0.2.14"
-log = { version = "0.4.14", features = ["max_level_debug", "release_max_level_debug"] }
-env_logger = "0.9.0"
-rand = "0.8.4"
-esp-idf-sys = { version = "0.30", features = ["binstart"], optional = true }
-openssl = { git = "https://github.com/sfackler/rust-openssl", optional = true}
-foreign-types = { version = "0.3.1", optional = true}
-sha2 = { version = "0.9.8", optional = true}
-hmac = { version = "0.11.0", optional = true}
-mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", optional = true}
+num-traits = "0.2.15"
+log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_debug"] }
+env_logger = "0.10.0"
+rand = "0.8.5"
+esp-idf-sys = { version = "0.32", features = ["binstart"], optional = true }
+openssl = { git = "https://github.com/sfackler/rust-openssl", optional = true }
+foreign-types = { version = "0.5.0", optional = true }
+sha2 = { version = "0.10.6", optional = true }
+hmac = { version = "0.12.1", optional = true }
+mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", optional = true }
 subtle = "2.4.1"
 colored = "2.0.0"
-smol = "1.2.5"
+smol = "1.3.0"
 owning_ref = "0.4.1"
 safemem = "0.3.3"
-chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
-async-channel = "1.6"
+chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
+async-channel = "1.8"
 
 # to compute the check digit
 verhoeff = "1"

--- a/matter/Cargo.toml
+++ b/matter/Cargo.toml
@@ -35,9 +35,9 @@ env_logger = "0.10.0"
 rand = "0.8.5"
 esp-idf-sys = { version = "0.32", features = ["binstart"], optional = true }
 openssl = { git = "https://github.com/sfackler/rust-openssl", optional = true }
-foreign-types = { version = "0.5.0", optional = true }
+foreign-types = { version = "0.4.0", optional = true }
 sha2 = { version = "0.10.6", optional = true }
-hmac = { version = "0.12.1", optional = true }
+hmac = { version = "0.11.0", optional = true }
 mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", optional = true }
 subtle = "2.4.1"
 colored = "2.0.0"


### PR DESCRIPTION
Small PR that adds a Cargo workspace to the project to make is slightly more ergonomic to use.

You can now build the project and run the example from the root:

```
cargo test
cargo build
RUST_LOG="matter" cargo run --example onoff_light
```

Also:
- Updated the matter `Cargo.toml` with the latest dependencies.
- Updated the README to reflect the updated build operations, and included an alternative pairing instruction that uses the Pairing Code.
