### PR TITLE
Support more common cluster attributes

### DIFF
--- a/examples/onoff_light/src/main.rs
+++ b/examples/onoff_light/src/main.rs
@@ -35,6 +35,7 @@ fn main() {
         pid: 0x8002,
         hw_ver: 2,
         sw_ver: 1,
+        sw_ver_str: "1".to_string(),
         serial_no: "aabbccdd".to_string(),
         device_name: "OnOff Light".to_string(),
     };

--- a/matter/src/data_model/cluster_basic_information.rs
+++ b/matter/src/data_model/cluster_basic_information.rs
@@ -28,6 +28,7 @@ enum Attributes {
     ProductId = 4,
     HwVer = 7,
     SwVer = 9,
+    SwVerString = 0xa,
     SerialNo = 0x0f,
 }
 
@@ -37,6 +38,7 @@ pub struct BasicInfoConfig {
     pub pid: u16,
     pub hw_ver: u16,
     pub sw_ver: u32,
+    pub sw_ver_str: String,
     pub serial_no: String,
     /// Device name; up to 32 characters
     pub device_name: String,
@@ -80,6 +82,12 @@ impl BasicInfoCluster {
             Attribute::new(
                 Attributes::SwVer as u16,
                 AttrValue::Uint32(cfg.sw_ver),
+                Access::RV,
+                Quality::FIXED,
+            )?,
+            Attribute::new(
+                Attributes::SwVerString as u16,
+                AttrValue::Utf8(cfg.sw_ver_str),
                 Access::RV,
                 Quality::FIXED,
             )?,

--- a/matter/src/data_model/cluster_basic_information.rs
+++ b/matter/src/data_model/cluster_basic_information.rs
@@ -42,59 +42,6 @@ pub struct BasicInfoConfig {
     pub device_name: String,
 }
 
-fn attr_dm_rev_new() -> Result<Attribute, Error> {
-    Attribute::new(
-        Attributes::DMRevision as u16,
-        AttrValue::Uint8(1),
-        Access::RV,
-        Quality::FIXED,
-    )
-}
-
-fn attr_vid_new(vid: u16) -> Result<Attribute, Error> {
-    Attribute::new(
-        Attributes::VendorId as u16,
-        AttrValue::Uint16(vid),
-        Access::RV,
-        Quality::FIXED,
-    )
-}
-
-fn attr_pid_new(pid: u16) -> Result<Attribute, Error> {
-    Attribute::new(
-        Attributes::ProductId as u16,
-        AttrValue::Uint16(pid),
-        Access::RV,
-        Quality::FIXED,
-    )
-}
-
-fn attr_hw_ver_new(hw_ver: u16) -> Result<Attribute, Error> {
-    Attribute::new(
-        Attributes::HwVer as u16,
-        AttrValue::Uint16(hw_ver),
-        Access::RV,
-        Quality::FIXED,
-    )
-}
-
-fn attr_sw_ver_new(sw_ver: u32) -> Result<Attribute, Error> {
-    Attribute::new(
-        Attributes::SwVer as u16,
-        AttrValue::Uint32(sw_ver),
-        Access::RV,
-        Quality::FIXED,
-    )
-}
-
-fn attr_serial_no_new(label: String) -> Result<Attribute, Error> {
-    Attribute::new(
-        Attributes::SerialNo as u16,
-        AttrValue::Utf8(label),
-        Access::RV,
-        Quality::FIXED,
-    )
-}
 pub struct BasicInfoCluster {
     base: Cluster,
 }
@@ -104,14 +51,47 @@ impl BasicInfoCluster {
         let mut cluster = Box::new(BasicInfoCluster {
             base: Cluster::new(ID)?,
         });
-        cluster.base.add_attribute(attr_dm_rev_new()?)?;
-        cluster.base.add_attribute(attr_vid_new(cfg.vid)?)?;
-        cluster.base.add_attribute(attr_pid_new(cfg.pid)?)?;
-        cluster.base.add_attribute(attr_hw_ver_new(cfg.hw_ver)?)?;
-        cluster.base.add_attribute(attr_sw_ver_new(cfg.sw_ver)?)?;
-        cluster
-            .base
-            .add_attribute(attr_serial_no_new(cfg.serial_no)?)?;
+
+        let attrs = [
+            Attribute::new(
+                Attributes::DMRevision as u16,
+                AttrValue::Uint8(1),
+                Access::RV,
+                Quality::FIXED,
+            )?,
+            Attribute::new(
+                Attributes::VendorId as u16,
+                AttrValue::Uint16(cfg.vid),
+                Access::RV,
+                Quality::FIXED,
+            )?,
+            Attribute::new(
+                Attributes::ProductId as u16,
+                AttrValue::Uint16(cfg.pid),
+                Access::RV,
+                Quality::FIXED,
+            )?,
+            Attribute::new(
+                Attributes::HwVer as u16,
+                AttrValue::Uint16(cfg.hw_ver),
+                Access::RV,
+                Quality::FIXED,
+            )?,
+            Attribute::new(
+                Attributes::SwVer as u16,
+                AttrValue::Uint32(cfg.sw_ver),
+                Access::RV,
+                Quality::FIXED,
+            )?,
+            Attribute::new(
+                Attributes::SerialNo as u16,
+                AttrValue::Utf8(cfg.serial_no),
+                Access::RV,
+                Quality::FIXED,
+            )?,
+        ];
+        cluster.base.add_attributes(&attrs[..])?;
+
         Ok(cluster)
     }
 }

--- a/matter/src/data_model/objects/attribute.rs
+++ b/matter/src/data_model/objects/attribute.rs
@@ -151,7 +151,7 @@ impl AttrValue {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Attribute {
     pub(super) id: u16,
     pub(super) value: AttrValue,

--- a/matter/src/data_model/objects/cluster.rs
+++ b/matter/src/data_model/objects/cluster.rs
@@ -30,7 +30,7 @@ use std::fmt::{self, Debug};
 
 use super::Encoder;
 
-pub const ATTRS_PER_CLUSTER: usize = 8;
+pub const ATTRS_PER_CLUSTER: usize = 10;
 pub const CMDS_PER_CLUSTER: usize = 8;
 
 #[derive(FromPrimitive, Debug)]
@@ -130,6 +130,15 @@ impl Cluster {
             Access::RV,
             Quality::NONE,
         )?)
+    }
+
+    pub fn add_attributes(&mut self, attrs: &[Attribute]) -> Result<(), Error> {
+        if self.attributes.len() + attrs.len() <= self.attributes.capacity() {
+            self.attributes.extend_from_slice(attrs);
+            Ok(())
+        } else {
+            Err(Error::NoSpace)
+        }
     }
 
     pub fn add_attribute(&mut self, attr: Attribute) -> Result<(), Error> {

--- a/matter/src/data_model/system_model/descriptor.rs
+++ b/matter/src/data_model/system_model/descriptor.rs
@@ -48,9 +48,27 @@ impl DescriptorCluster {
             data_model,
             base: Cluster::new(ID)?,
         });
-        c.base.add_attribute(attr_devtypelist_new()?)?;
-        c.base.add_attribute(attr_serverlist_new()?)?;
-        c.base.add_attribute(attr_partslist_new()?)?;
+        let attrs = [
+            Attribute::new(
+                Attributes::DeviceTypeList as u16,
+                AttrValue::Custom,
+                Access::RV,
+                Quality::NONE,
+            )?,
+            Attribute::new(
+                Attributes::ServerList as u16,
+                AttrValue::Custom,
+                Access::RV,
+                Quality::NONE,
+            )?,
+            Attribute::new(
+                Attributes::PartsList as u16,
+                AttrValue::Custom,
+                Access::RV,
+                Quality::NONE,
+            )?,
+        ];
+        c.base.add_attributes(&attrs[..])?;
         Ok(c)
     }
 
@@ -132,30 +150,4 @@ impl ClusterType for DescriptorCluster {
             }
         }
     }
-}
-
-fn attr_devtypelist_new() -> Result<Attribute, Error> {
-    Attribute::new(
-        Attributes::DeviceTypeList as u16,
-        AttrValue::Custom,
-        Access::RV,
-        Quality::NONE,
-    )
-}
-fn attr_serverlist_new() -> Result<Attribute, Error> {
-    Attribute::new(
-        Attributes::ServerList as u16,
-        AttrValue::Custom,
-        Access::RV,
-        Quality::NONE,
-    )
-}
-
-fn attr_partslist_new() -> Result<Attribute, Error> {
-    Attribute::new(
-        Attributes::PartsList as u16,
-        AttrValue::Custom,
-        Access::RV,
-        Quality::NONE,
-    )
 }

--- a/matter/src/fabric.rs
+++ b/matter/src/fabric.rs
@@ -364,6 +364,17 @@ impl FabricMgr {
         true
     }
 
+    pub fn used_count(&self) -> usize {
+        let mgr = self.inner.read().unwrap();
+        let mut count = 0;
+        for i in 1..MAX_SUPPORTED_FABRICS {
+            if mgr.fabrics[i].is_some() {
+                count += 1;
+            }
+        }
+        count
+    }
+
     // Parameters to T are the Fabric and its Fabric Index
     pub fn for_each<T>(&self, mut f: T) -> Result<(), Error>
     where

--- a/matter/src/lib.rs
+++ b/matter/src/lib.rs
@@ -49,6 +49,7 @@
 //!     pid: 0xFFF1,
 //!     hw_ver: 2,
 //!     sw_ver: 1,
+//!     sw_ver_str: "1".to_string(),
 //!     serial_no: "aabbcc".to_string(),
 //!     device_name: "OnOff Light".to_string(),
 //! };

--- a/matter/tests/common/im_engine.rs
+++ b/matter/tests/common/im_engine.rs
@@ -94,6 +94,7 @@ impl ImEngine {
             pid: 11,
             hw_ver: 12,
             sw_ver: 13,
+            sw_ver_str: "13".to_string(),
             serial_no: "aabbccdd".to_string(),
             device_name: "Test Device".to_string(),
         };


### PR DESCRIPTION
Add support for more common attributes that are queried by iOS/Google during their commissioning process