### PR TITLE
Derive PartialOrd for AttrValue so we can compare them directly 

### DIFF
--- a/matter/src/data_model/objects/attribute.rs
+++ b/matter/src/data_model/objects/attribute.rs
@@ -88,7 +88,7 @@ bitflags! {
  * - instead of arrays, can use linked-lists to conserve space and avoid the internal fragmentation
  */
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, PartialOrd, Clone)]
 pub enum AttrValue {
     Int64(i64),
     Uint8(u8),


### PR DESCRIPTION
This trait allows us to directly compare AttrValue of the same size. It's really useful for implementing numeric attributes - I'll be opening a PR soon implementing LevelControl cluster and updating the CurrentLevel is a pain without this - unwrap a Result<AttrValue, Err> into a u8, compare to u8, construct new AttrValue and update. 