### PR TITLE
Make read_attribute() part of ClusterType instead of Cluster.

### DIFF
--- a/matter/src/data_model/core.rs
+++ b/matter/src/data_model/core.rs
@@ -180,7 +180,7 @@ impl DataModel {
             // Set the cluster's data version
             attr_encoder.set_data_ver(cluster_data_ver);
             let mut access_req = AccessReq::new(accessor, path, Access::READ);
-            Cluster::read_attribute(c, &mut access_req, attr_encoder, attr_details);
+            c.read_attribute(&mut access_req, attr_encoder, &attr_details);
             Ok(())
         });
         if let Err(e) = result {

--- a/matter/src/data_model/objects/attribute.rs
+++ b/matter/src/data_model/objects/attribute.rs
@@ -154,9 +154,9 @@ impl AttrValue {
 #[derive(Debug, Clone)]
 pub struct Attribute {
     pub(super) id: u16,
-    pub(super) value: AttrValue,
+    pub value: AttrValue,
     pub(super) quality: Quality,
-    pub(super) access: Access,
+    pub access: Access,
 }
 
 impl Default for Attribute {

--- a/matter/src/data_model/objects/cluster.rs
+++ b/matter/src/data_model/objects/cluster.rs
@@ -190,7 +190,7 @@ impl Cluster {
         self.attributes.iter().position(|c| c.id == attr_id)
     }
 
-    fn get_attribute(&self, attr_id: u16) -> Result<&Attribute, Error> {
+    pub fn get_attribute(&self, attr_id: u16) -> Result<&Attribute, Error> {
         let index = self
             .get_attribute_index(attr_id)
             .ok_or(Error::AttributeNotFound)?;
@@ -228,7 +228,7 @@ impl Cluster {
         let _ = tw.end_container();
     }
 
-    fn read_system_attribute(&self, encoder: &mut dyn Encoder, attr: &Attribute) {
+    pub fn read_system_attribute(&self, encoder: &mut dyn Encoder, attr: &Attribute) {
         let global_attr: Option<GlobalElements> = num::FromPrimitive::from_u16(attr.id);
         if let Some(global_attr) = global_attr {
             match global_attr {


### PR DESCRIPTION
Just moves read_attribute() from Cluster to ClusterType.

Most clusters will not see a difference as they will just use the same default implementation.
This is useful for implementing long-running commands that will update some values - a given cluster can implement their own version of read_attribute() so it will pick up values updated in the background over a period of seconds.

This is a dependency to get a per-cluster event loop in a separate thread - values are saved into a middle store inside the cluster and reads will pick them up if they are newer than the data model values.
I admit this is not great, I would love a more idiomatic approach, but most pieces of the data model are very immutable in their own contexts and wrapping anything in the actual data model inside a Mutex<> will require a lot of rewriting.