### PR TITLE
Support multi-hop reads

### DIFF
--- a/matter/src/data_model/core/mod.rs
+++ b/matter/src/data_model/core/mod.rs
@@ -76,17 +76,6 @@ impl DataModel {
         Ok(dm)
     }
 
-    pub fn read_attribute_raw(
-        &self,
-        endpoint: u16,
-        cluster: u32,
-        attr: u16,
-    ) -> Result<AttrValue, IMStatusCode> {
-        let node = self.node.read().unwrap();
-        let cluster = node.get_cluster(endpoint, cluster)?;
-        cluster.base().read_attribute_raw(attr).map(|a| a.clone())
-    }
-
     // Encode a write attribute from a path that may or may not be wildcard
     fn handle_write_attr_path(
         node: &mut Node,
@@ -151,67 +140,6 @@ impl DataModel {
             // We hit this only if this is a non-wildcard path and some parts of the path are missing
             encoder.encode_status(e, 0);
         }
-    }
-
-    /// Encode a read attribute from a path that may or may not be wildcard
-    ///
-    /// If the buffer gets full while generating the read response, we will return
-    /// an Err(path), where the path is the path that we should resume from, for the next chunk.
-    /// This facilitates chunk management
-    fn handle_read_attr_path(
-        node: &Node,
-        accessor: &Accessor,
-        attr_encoder: &mut AttrReadEncoder,
-        attr_details: &mut AttrDetails,
-        resume_from: &mut Option<GenericPath>,
-    ) -> Result<(), Error> {
-        let mut status = Ok(());
-        let path = attr_encoder.path;
-
-        // Skip error reporting for wildcard paths, don't for concrete paths
-        attr_encoder.skip_error(path.is_wildcard());
-
-        let result = node.for_each_attribute(&path, |path, c| {
-            // Ignore processing if data filter matches.
-            // For a wildcard attribute, this may end happening unnecessarily for all attributes, although
-            // a single skip for the cluster is sufficient. That requires us to replace this for_each with a
-            // for_each_cluster
-            let cluster_data_ver = c.base().get_dataver();
-            if Self::data_filter_matches(&attr_encoder.data_ver_filters, path, cluster_data_ver) {
-                return Ok(());
-            }
-
-            // The resume_from indicates that this is the next chunk of a previous Read Request. In such cases, we
-            // need to skip until we hit this path.
-            if let Some(r) = resume_from {
-                // If resume_from is valid, and we haven't hit the resume_from yet, skip encoding
-                if r != path {
-                    return Ok(());
-                } else {
-                    // Else, wipe out the resume_from so subsequent paths can be encoded
-                    *resume_from = None;
-                }
-            }
-
-            attr_details.attr_id = path.leaf.unwrap_or_default() as u16;
-            // Overwrite the previous path with the concrete path
-            attr_encoder.set_path(*path);
-            // Set the cluster's data version
-            attr_encoder.set_data_ver(cluster_data_ver);
-            let mut access_req = AccessReq::new(accessor, path, Access::READ);
-            Cluster::read_attribute(c, &mut access_req, attr_encoder, attr_details);
-            if attr_encoder.is_buffer_full() {
-                // Buffer is full, next time resume from this attribute
-                *resume_from = Some(*path);
-                status = Err(Error::NoSpace);
-            }
-            Ok(())
-        });
-        if let Err(e) = result {
-            // We hit this only if this is a non-wildcard path
-            attr_encoder.encode_status(e, 0);
-        }
-        status
     }
 
     // Handle command from a path that may or may not be wildcard
@@ -291,31 +219,13 @@ impl DataModel {
     }
 }
 
+pub mod read;
+
 impl objects::ChangeConsumer for DataModel {
     fn endpoint_added(&self, id: u16, endpoint: &mut Endpoint) -> Result<(), Error> {
         endpoint.add_cluster(DescriptorCluster::new(id, self.clone())?)?;
         Ok(())
     }
-}
-
-/// State to maintain when a Read Request needs to be resumed
-/// resumed - the next chunk of the read needs to be returned
-#[derive(Default)]
-pub struct ResumeReadReq {
-    /// The Read Request Attribute Path that caused chunking, and this is the path
-    /// that needs to be resumed.
-    ///
-    /// TODO: Ideally, the entire ReadRequest (with any subsequent AttrPaths) should also
-    /// be maintained. But for now, we just store the AttrPath that caused the overflow
-    /// and chunking. Hopefully, the other end requests any pending paths when it sees no
-    /// more chunks.
-    pending_path: GenericPath,
-
-    /// The Attribute that couldn't be encoded because our buffer got full. The next chunk
-    /// will start encoding from this attribute onwards.
-    /// Note that given wildcard reads, one PendingPath in the member above can generated
-    /// multiple encode paths. Hence this has to be maintained separately.
-    resume_encode: Option<GenericPath>,
 }
 
 impl InteractionConsumer for DataModel {
@@ -339,64 +249,11 @@ impl InteractionConsumer for DataModel {
 
     fn consume_read_attr(
         &self,
-        read_req: &ReadReq,
+        req: &ReadReq,
         trans: &mut Transaction,
         tw: &mut TLVWriter,
     ) -> Result<(), Error> {
-        let mut resume_read_req: ResumeReadReq = Default::default();
-
-        let mut attr_encoder = AttrReadEncoder::new(tw);
-        if let Some(filters) = &read_req.dataver_filters {
-            attr_encoder.set_data_ver_filters(filters);
-        }
-
-        if let Some(attr_requests) = &read_req.attr_requests {
-            let accessor = self.sess_to_accessor(trans.session);
-            let mut attr_details = AttrDetails::new(accessor.fab_idx, read_req.fabric_filtered);
-            let node = self.node.read().unwrap();
-            attr_encoder
-                .tw
-                .start_array(TagType::Context(msg::ReportDataTag::AttributeReports as u8))?;
-
-            let mut result = Ok(());
-            for attr_path in attr_requests.iter() {
-                attr_encoder.set_path(attr_path.to_gp());
-                // Extract the attr_path fields into various structures
-                attr_details.list_index = attr_path.list_index;
-                result = DataModel::handle_read_attr_path(
-                    &node,
-                    &accessor,
-                    &mut attr_encoder,
-                    &mut attr_details,
-                    &mut resume_read_req.resume_encode,
-                );
-                if result.is_err() {
-                    resume_read_req.pending_path = attr_path.to_gp();
-                    break;
-                }
-            }
-            tw.end_container()?;
-            if result.is_err() {
-                // If there was an error, indicate chunking. The resume_read_req would have been
-                // already populated from in the loop above.
-                tw.bool(
-                    TagType::Context(msg::ReportDataTag::MoreChunkedMsgs as u8),
-                    true,
-                )?;
-                tw.bool(
-                    TagType::Context(msg::ReportDataTag::SupressResponse as u8),
-                    false,
-                )?;
-                // Don't complete the transaction
-            } else {
-                tw.bool(
-                    TagType::Context(msg::ReportDataTag::SupressResponse as u8),
-                    true,
-                )?;
-                trans.complete();
-            }
-        }
-        Ok(())
+        self.handle_read_attr_array(req, trans, tw)
     }
 
     fn consume_invoke_cmd(
@@ -428,73 +285,6 @@ impl InteractionConsumer for DataModel {
         }
 
         Ok(())
-    }
-}
-
-/// Encoder for generating a response to a read request
-pub struct AttrReadEncoder<'a, 'b, 'c> {
-    tw: &'a mut TLVWriter<'b, 'c>,
-    data_ver: u32,
-    path: GenericPath,
-    skip_error: bool,
-    data_ver_filters: Option<&'a TLVArray<'a, DataVersionFilter>>,
-    is_buffer_full: bool,
-}
-
-impl<'a, 'b, 'c> AttrReadEncoder<'a, 'b, 'c> {
-    pub fn new(tw: &'a mut TLVWriter<'b, 'c>) -> Self {
-        Self {
-            tw,
-            data_ver: 0,
-            skip_error: false,
-            path: Default::default(),
-            data_ver_filters: None,
-            is_buffer_full: false,
-        }
-    }
-
-    pub fn skip_error(&mut self, skip: bool) {
-        self.skip_error = skip;
-    }
-
-    pub fn set_data_ver(&mut self, data_ver: u32) {
-        self.data_ver = data_ver;
-    }
-
-    pub fn set_data_ver_filters(&mut self, filters: &'a TLVArray<'a, DataVersionFilter>) {
-        self.data_ver_filters = Some(filters);
-    }
-
-    pub fn set_path(&mut self, path: GenericPath) {
-        self.path = path;
-    }
-
-    pub fn is_buffer_full(&self) -> bool {
-        self.is_buffer_full
-    }
-}
-
-impl<'a, 'b, 'c> Encoder for AttrReadEncoder<'a, 'b, 'c> {
-    fn encode(&mut self, value: EncodeValue) {
-        let resp = ib::AttrResp::Data(ib::AttrData::new(
-            Some(self.data_ver),
-            ib::AttrPath::new(&self.path),
-            value,
-        ));
-
-        let anchor = self.tw.get_tail();
-        if resp.to_tlv(self.tw, TagType::Anonymous).is_err() {
-            self.is_buffer_full = true;
-            self.tw.rewind_to(anchor);
-        }
-    }
-
-    fn encode_status(&mut self, status: IMStatusCode, cluster_status: u16) {
-        if !self.skip_error {
-            let resp =
-                ib::AttrResp::Status(ib::AttrStatus::new(&self.path, status, cluster_status));
-            let _ = resp.to_tlv(self.tw, TagType::Anonymous);
-        }
     }
 }
 

--- a/matter/src/data_model/core/read.rs
+++ b/matter/src/data_model/core/read.rs
@@ -34,6 +34,7 @@ use crate::{
     wb_shrink, wb_unshrink,
 };
 use log::error;
+
 /// Encoder for generating a response to a read request
 pub struct AttrReadEncoder<'a, 'b, 'c> {
     tw: &'a mut TLVWriter<'b, 'c>,
@@ -107,13 +108,13 @@ impl<'a, 'b, 'c> Encoder for AttrReadEncoder<'a, 'b, 'c> {
 pub struct ResumeReadReq {
     /// The Read Request Attribute Path that caused chunking, and this is the path
     /// that needs to be resumed.
-    pending_req: Option<Packet<'static>>,
+    pub pending_req: Option<Packet<'static>>,
 
     /// The Attribute that couldn't be encoded because our buffer got full. The next chunk
     /// will start encoding from this attribute onwards.
     /// Note that given wildcard reads, one PendingPath in the member above can generated
     /// multiple encode paths. Hence this has to be maintained separately.
-    resume_from: Option<GenericPath>,
+    pub resume_from: Option<GenericPath>,
 }
 impl ResumeReadReq {
     pub fn new(rx_buf: &[u8], resume_from: &Option<GenericPath>) -> Result<Self, Error> {

--- a/matter/src/data_model/core/read.rs
+++ b/matter/src/data_model/core/read.rs
@@ -1,0 +1,246 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+use crate::data_model::{core::DataModel, objects::*};
+use crate::{
+    acl::{AccessReq, Accessor},
+    error::*,
+    interaction_model::{
+        core::IMStatusCode,
+        messages::{
+            ib::{self, DataVersionFilter},
+            msg::{self, ReadReq, ReportDataTag::MoreChunkedMsgs, ReportDataTag::SupressResponse},
+            GenericPath,
+        },
+        Transaction,
+    },
+    tlv::{TLVArray, TLVWriter, TagType, ToTLV},
+};
+
+/// Encoder for generating a response to a read request
+pub struct AttrReadEncoder<'a, 'b, 'c> {
+    tw: &'a mut TLVWriter<'b, 'c>,
+    data_ver: u32,
+    path: GenericPath,
+    skip_error: bool,
+    data_ver_filters: Option<&'a TLVArray<'a, DataVersionFilter>>,
+    is_buffer_full: bool,
+}
+
+impl<'a, 'b, 'c> AttrReadEncoder<'a, 'b, 'c> {
+    pub fn new(tw: &'a mut TLVWriter<'b, 'c>) -> Self {
+        Self {
+            tw,
+            data_ver: 0,
+            skip_error: false,
+            path: Default::default(),
+            data_ver_filters: None,
+            is_buffer_full: false,
+        }
+    }
+
+    pub fn skip_error(&mut self, skip: bool) {
+        self.skip_error = skip;
+    }
+
+    pub fn set_data_ver(&mut self, data_ver: u32) {
+        self.data_ver = data_ver;
+    }
+
+    pub fn set_data_ver_filters(&mut self, filters: &'a TLVArray<'a, DataVersionFilter>) {
+        self.data_ver_filters = Some(filters);
+    }
+
+    pub fn set_path(&mut self, path: GenericPath) {
+        self.path = path;
+    }
+
+    pub fn is_buffer_full(&self) -> bool {
+        self.is_buffer_full
+    }
+}
+
+impl<'a, 'b, 'c> Encoder for AttrReadEncoder<'a, 'b, 'c> {
+    fn encode(&mut self, value: EncodeValue) {
+        let resp = ib::AttrResp::Data(ib::AttrData::new(
+            Some(self.data_ver),
+            ib::AttrPath::new(&self.path),
+            value,
+        ));
+
+        let anchor = self.tw.get_tail();
+        if resp.to_tlv(self.tw, TagType::Anonymous).is_err() {
+            self.is_buffer_full = true;
+            self.tw.rewind_to(anchor);
+        }
+    }
+
+    fn encode_status(&mut self, status: IMStatusCode, cluster_status: u16) {
+        if !self.skip_error {
+            let resp =
+                ib::AttrResp::Status(ib::AttrStatus::new(&self.path, status, cluster_status));
+            let _ = resp.to_tlv(self.tw, TagType::Anonymous);
+        }
+    }
+}
+
+/// State to maintain when a Read Request needs to be resumed
+/// resumed - the next chunk of the read needs to be returned
+#[derive(Default)]
+pub struct ResumeReadReq {
+    /// The Read Request Attribute Path that caused chunking, and this is the path
+    /// that needs to be resumed.
+    ///
+    /// TODO: Ideally, the entire ReadRequest (with any subsequent AttrPaths) should also
+    /// be maintained. But for now, we just store the AttrPath that caused the overflow
+    /// and chunking. Hopefully, the other end requests any pending paths when it sees no
+    /// more chunks.
+    pending_path: GenericPath,
+
+    /// The Attribute that couldn't be encoded because our buffer got full. The next chunk
+    /// will start encoding from this attribute onwards.
+    /// Note that given wildcard reads, one PendingPath in the member above can generated
+    /// multiple encode paths. Hence this has to be maintained separately.
+    resume_encode: Option<GenericPath>,
+}
+
+impl DataModel {
+    pub fn read_attribute_raw(
+        &self,
+        endpoint: u16,
+        cluster: u32,
+        attr: u16,
+    ) -> Result<AttrValue, IMStatusCode> {
+        let node = self.node.read().unwrap();
+        let cluster = node.get_cluster(endpoint, cluster)?;
+        cluster.base().read_attribute_raw(attr).map(|a| a.clone())
+    }
+    /// Encode a read attribute from a path that may or may not be wildcard
+    ///
+    /// If the buffer gets full while generating the read response, we will return
+    /// an Err(path), where the path is the path that we should resume from, for the next chunk.
+    /// This facilitates chunk management
+    fn handle_read_attr_path(
+        node: &Node,
+        accessor: &Accessor,
+        attr_encoder: &mut AttrReadEncoder,
+        attr_details: &mut AttrDetails,
+        resume_from: &mut Option<GenericPath>,
+    ) -> Result<(), Error> {
+        let mut status = Ok(());
+        let path = attr_encoder.path;
+
+        // Skip error reporting for wildcard paths, don't for concrete paths
+        attr_encoder.skip_error(path.is_wildcard());
+
+        let result = node.for_each_attribute(&path, |path, c| {
+            // Ignore processing if data filter matches.
+            // For a wildcard attribute, this may end happening unnecessarily for all attributes, although
+            // a single skip for the cluster is sufficient. That requires us to replace this for_each with a
+            // for_each_cluster
+            let cluster_data_ver = c.base().get_dataver();
+            if Self::data_filter_matches(&attr_encoder.data_ver_filters, path, cluster_data_ver) {
+                return Ok(());
+            }
+
+            // The resume_from indicates that this is the next chunk of a previous Read Request. In such cases, we
+            // need to skip until we hit this path.
+            if let Some(r) = resume_from {
+                // If resume_from is valid, and we haven't hit the resume_from yet, skip encoding
+                if r != path {
+                    return Ok(());
+                } else {
+                    // Else, wipe out the resume_from so subsequent paths can be encoded
+                    *resume_from = None;
+                }
+            }
+
+            attr_details.attr_id = path.leaf.unwrap_or_default() as u16;
+            // Overwrite the previous path with the concrete path
+            attr_encoder.set_path(*path);
+            // Set the cluster's data version
+            attr_encoder.set_data_ver(cluster_data_ver);
+            let mut access_req = AccessReq::new(accessor, path, Access::READ);
+            Cluster::read_attribute(c, &mut access_req, attr_encoder, attr_details);
+            if attr_encoder.is_buffer_full() {
+                // Buffer is full, next time resume from this attribute
+                *resume_from = Some(*path);
+                status = Err(Error::NoSpace);
+            }
+            Ok(())
+        });
+        if let Err(e) = result {
+            // We hit this only if this is a non-wildcard path
+            attr_encoder.encode_status(e, 0);
+        }
+        status
+    }
+
+    /// Process an array of Attribute Read Requests
+    pub(super) fn handle_read_attr_array(
+        &self,
+        read_req: &ReadReq,
+        trans: &mut Transaction,
+        tw: &mut TLVWriter,
+    ) -> Result<(), Error> {
+        let mut resume_read_req: ResumeReadReq = Default::default();
+
+        let mut attr_encoder = AttrReadEncoder::new(tw);
+        if let Some(filters) = &read_req.dataver_filters {
+            attr_encoder.set_data_ver_filters(filters);
+        }
+
+        if let Some(attr_requests) = &read_req.attr_requests {
+            let accessor = self.sess_to_accessor(trans.session);
+            let mut attr_details = AttrDetails::new(accessor.fab_idx, read_req.fabric_filtered);
+            let node = self.node.read().unwrap();
+            attr_encoder
+                .tw
+                .start_array(TagType::Context(msg::ReportDataTag::AttributeReports as u8))?;
+
+            let mut result = Ok(());
+            for attr_path in attr_requests.iter() {
+                attr_encoder.set_path(attr_path.to_gp());
+                // Extract the attr_path fields into various structures
+                attr_details.list_index = attr_path.list_index;
+                result = DataModel::handle_read_attr_path(
+                    &node,
+                    &accessor,
+                    &mut attr_encoder,
+                    &mut attr_details,
+                    &mut resume_read_req.resume_encode,
+                );
+                if result.is_err() {
+                    resume_read_req.pending_path = attr_path.to_gp();
+                    break;
+                }
+            }
+            tw.end_container()?;
+            if result.is_err() {
+                // If there was an error, indicate chunking. The resume_read_req would have been
+                // already populated from in the loop above.
+                tw.bool(TagType::Context(MoreChunkedMsgs as u8), true)?;
+                tw.bool(TagType::Context(SupressResponse as u8), false)?;
+                // Don't complete the transaction
+            } else {
+                tw.bool(TagType::Context(SupressResponse as u8), true)?;
+                trans.complete();
+            }
+        }
+        Ok(())
+    }
+}

--- a/matter/src/data_model/core/subscribe.rs
+++ b/matter/src/data_model/core/subscribe.rs
@@ -50,7 +50,8 @@ impl DataModel {
             TagType::Context(msg::ReportDataTag::SubscriptionId as u8),
             ctx.id,
         )?;
-        self.handle_read_attr_array(&read_req, trans, tw)?;
+        let mut resume_from = None;
+        self.handle_read_attr_array(&read_req, trans, tw, &mut resume_from)?;
         tw.end_container()?;
 
         Ok(ctx)

--- a/matter/src/data_model/core/subscribe.rs
+++ b/matter/src/data_model/core/subscribe.rs
@@ -21,71 +21,122 @@ use crate::{
     error::Error,
     interaction_model::{
         core::OpCode,
-        messages::msg::{self, SubscribeReq, SubscribeResp},
+        messages::{
+            msg::{self, SubscribeReq, SubscribeResp},
+            GenericPath,
+        },
     },
-    tlv::{TLVWriter, TagType, ToTLV},
+    tlv::{self, get_root_node_struct, FromTLV, TLVWriter, TagType, ToTLV},
     transport::proto_demux::ResponseRequired,
 };
 
-use super::{DataModel, Transaction};
+use super::{read::ResumeReadReq, DataModel, Transaction};
 
 static SUBS_ID: AtomicU32 = AtomicU32::new(1);
 
-impl DataModel {
-    pub fn handle_subscribe_req(
-        &self,
-        req: &SubscribeReq,
-        trans: &mut Transaction,
-        tw: &mut TLVWriter,
-    ) -> Result<SubsCtx, Error> {
-        let ctx = SubsCtx {
-            state: SubsState::Confirming,
-            // TODO
-            id: SUBS_ID.fetch_add(1, Ordering::SeqCst),
-        };
-
-        let read_req = req.to_read_req();
-        tw.start_struct(TagType::Anonymous)?;
-        tw.u32(
-            TagType::Context(msg::ReportDataTag::SubscriptionId as u8),
-            ctx.id,
-        )?;
-        let mut resume_from = None;
-        self.handle_read_attr_array(&read_req, trans, tw, &mut resume_from)?;
-        tw.end_container()?;
-
-        Ok(ctx)
-    }
-
-    pub fn handle_subscription_confirm(
-        &self,
-        trans: &mut Transaction,
-        tw: &mut TLVWriter,
-        ctx: &mut SubsCtx,
-    ) -> Result<(OpCode, ResponseRequired), Error> {
-        if ctx.state != SubsState::Confirming {
-            // Not relevant for us
-            trans.complete();
-            return Err(Error::Invalid);
-        }
-        ctx.state = SubsState::Confirmed;
-
-        // TODO
-        let resp = SubscribeResp::new(ctx.id, 40);
-        resp.to_tlv(tw, TagType::Anonymous)?;
-        trans.complete();
-        Ok((OpCode::SubscriptResponse, ResponseRequired::Yes))
-    }
-}
-
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq)]
 enum SubsState {
     Confirming,
     Confirmed,
 }
 
-#[derive(Clone, Copy)]
 pub struct SubsCtx {
     state: SubsState,
     id: u32,
+    resume_read_req: Option<ResumeReadReq>,
+}
+
+impl SubsCtx {
+    pub fn new(
+        rx_buf: &[u8],
+        trans: &mut Transaction,
+        tw: &mut TLVWriter,
+        dm: &DataModel,
+    ) -> Result<Self, Error> {
+        let root = get_root_node_struct(rx_buf)?;
+        let req = SubscribeReq::from_tlv(&root)?;
+
+        let mut ctx = SubsCtx {
+            state: SubsState::Confirming,
+            // TODO
+            id: SUBS_ID.fetch_add(1, Ordering::SeqCst),
+            resume_read_req: None,
+        };
+
+        let mut resume_from = None;
+        ctx.do_read(&req, trans, tw, dm, &mut resume_from)?;
+        if resume_from.is_some() {
+            // This is a multi-hop read transaction, remember this read request
+            ctx.resume_read_req = Some(ResumeReadReq::new(rx_buf, &resume_from)?);
+        }
+        Ok(ctx)
+    }
+
+    pub fn handle_status_report(
+        &mut self,
+        trans: &mut Transaction,
+        tw: &mut TLVWriter,
+        dm: &DataModel,
+    ) -> Result<(OpCode, ResponseRequired), Error> {
+        if self.state != SubsState::Confirming {
+            // Not relevant for us
+            trans.complete();
+            return Err(Error::Invalid);
+        }
+
+        // Is there a previous resume read pending
+        if self.resume_read_req.is_some() {
+            let mut resume_read_req = self.resume_read_req.take().unwrap();
+            if let Some(packet) = resume_read_req.pending_req.as_mut() {
+                let rx_buf = packet.get_parsebuf()?.as_borrow_slice();
+                let root = tlv::get_root_node(rx_buf)?;
+                let req = SubscribeReq::from_tlv(&root)?;
+
+                self.do_read(&req, trans, tw, dm, &mut resume_read_req.resume_from)?;
+                if resume_read_req.resume_from.is_some() {
+                    // More chunks are pending, setup resume_read_req again
+                    self.resume_read_req = Some(resume_read_req);
+                }
+
+                return Ok((OpCode::ReportData, ResponseRequired::Yes));
+            }
+        }
+
+        // We are here implies that the read is now complete
+        self.confirm_subscription(trans, tw)
+    }
+
+    fn confirm_subscription(
+        &mut self,
+        trans: &mut Transaction,
+        tw: &mut TLVWriter,
+    ) -> Result<(OpCode, ResponseRequired), Error> {
+        self.state = SubsState::Confirmed;
+
+        // TODO
+        let resp = SubscribeResp::new(self.id, 40);
+        resp.to_tlv(tw, TagType::Anonymous)?;
+        trans.complete();
+        Ok((OpCode::SubscriptResponse, ResponseRequired::Yes))
+    }
+
+    fn do_read(
+        &mut self,
+        req: &SubscribeReq,
+        trans: &mut Transaction,
+        tw: &mut TLVWriter,
+        dm: &DataModel,
+        resume_from: &mut Option<GenericPath>,
+    ) -> Result<(), Error> {
+        let read_req = req.to_read_req();
+        tw.start_struct(TagType::Anonymous)?;
+        tw.u32(
+            TagType::Context(msg::ReportDataTag::SubscriptionId as u8),
+            self.id,
+        )?;
+        dm.handle_read_attr_array(&read_req, trans, tw, resume_from)?;
+        tw.end_container()?;
+
+        Ok(())
+    }
 }

--- a/matter/src/data_model/objects/cluster.rs
+++ b/matter/src/data_model/objects/cluster.rs
@@ -46,11 +46,28 @@ pub enum GlobalElements {
 
 // TODO: What if we instead of creating this, we just pass the AttrData/AttrPath to the read/write
 // methods?
+/// The Attribute Details structure records the details about the attribute under consideration.
+/// Typically this structure is progressively built as we proceed through the request processing.
 pub struct AttrDetails {
-    pub attr_id: u16,
-    pub list_index: Option<Nullable<u16>>,
-    pub fab_idx: u8,
+    /// Fabric Filtering Activated
     pub fab_filter: bool,
+    /// The current Fabric Index
+    pub fab_idx: u8,
+    /// List Index, if any
+    pub list_index: Option<Nullable<u16>>,
+    /// The actual attribute ID
+    pub attr_id: u16,
+}
+
+impl AttrDetails {
+    pub fn new(fab_idx: u8, fab_filter: bool) -> Self {
+        Self {
+            fab_filter,
+            fab_idx,
+            list_index: None,
+            attr_id: 0,
+        }
+    }
 }
 
 pub trait ClusterType {

--- a/matter/src/data_model/system_model/access_control.rs
+++ b/matter/src/data_model/system_model/access_control.rs
@@ -195,7 +195,7 @@ mod tests {
     use crate::{
         acl::{AclEntry, AclMgr, AuthMode},
         data_model::{
-            core::AttrReadEncoder,
+            core::read::AttrReadEncoder,
             objects::{AttrDetails, ClusterType, Privilege},
         },
         interaction_model::messages::ib::ListOperation,

--- a/matter/src/interaction_model/core.rs
+++ b/matter/src/interaction_model/core.rs
@@ -33,9 +33,9 @@ use log::{error, info};
 use num;
 use num_derive::FromPrimitive;
 
+use super::InteractionModel;
 use super::Transaction;
 use super::TransactionState;
-use super::{messages::msg::SubscribeReq, InteractionModel};
 use super::{messages::msg::TimedReq, InteractionConsumer};
 
 /* Handle messages related to the Interation Model
@@ -107,10 +107,7 @@ impl InteractionModel {
         proto_tx: &mut Packet,
     ) -> Result<ResponseRequired, Error> {
         let mut tw = TLVWriter::new(proto_tx.get_writebuf()?);
-        let root = get_root_node_struct(rx_buf)?;
-        let req = SubscribeReq::from_tlv(&root)?;
-
-        let (opcode, resp) = self.consumer.consume_subscribe(&req, trans, &mut tw)?;
+        let (opcode, resp) = self.consumer.consume_subscribe(rx_buf, trans, &mut tw)?;
         proto_tx.set_proto_opcode(opcode as u8);
         Ok(resp)
     }

--- a/matter/src/interaction_model/messages.rs
+++ b/matter/src/interaction_model/messages.rs
@@ -223,7 +223,7 @@ pub mod msg {
         SubscriptionId = 0,
         AttributeReports = 1,
         _EventReport = 2,
-        _MoreChunkedMsgs = 3,
+        MoreChunkedMsgs = 3,
         SupressResponse = 4,
     }
 

--- a/matter/src/interaction_model/mod.rs
+++ b/matter/src/interaction_model/mod.rs
@@ -18,10 +18,13 @@
 use crate::{
     error::Error,
     tlv::TLVWriter,
-    transport::{exchange::Exchange, session::Session},
+    transport::{exchange::Exchange, proto_demux::ResponseRequired, session::Session},
 };
 
-use self::messages::msg::{InvReq, ReadReq, WriteReq};
+use self::{
+    core::OpCode,
+    messages::msg::{InvReq, ReadReq, StatusResp, SubscribeReq, WriteReq},
+};
 
 #[derive(PartialEq)]
 pub enum TransactionState {
@@ -55,6 +58,20 @@ pub trait InteractionConsumer {
         trans: &mut Transaction,
         tw: &mut TLVWriter,
     ) -> Result<(), Error>;
+
+    fn consume_status_report(
+        &self,
+        _req: &StatusResp,
+        _trans: &mut Transaction,
+        _tw: &mut TLVWriter,
+    ) -> Result<(OpCode, ResponseRequired), Error>;
+
+    fn consume_subscribe(
+        &self,
+        _req: &SubscribeReq,
+        _trans: &mut Transaction,
+        _tw: &mut TLVWriter,
+    ) -> Result<(OpCode, ResponseRequired), Error>;
 }
 
 pub struct InteractionModel {
@@ -64,5 +81,4 @@ pub mod command;
 pub mod core;
 pub mod messages;
 pub mod read;
-pub mod subscribe;
 pub mod write;

--- a/matter/src/interaction_model/mod.rs
+++ b/matter/src/interaction_model/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use self::{
     core::OpCode,
-    messages::msg::{InvReq, ReadReq, StatusResp, SubscribeReq, WriteReq},
+    messages::msg::{InvReq, StatusResp, SubscribeReq, WriteReq},
 };
 
 #[derive(PartialEq)]
@@ -47,7 +47,9 @@ pub trait InteractionConsumer {
 
     fn consume_read_attr(
         &self,
-        req: &ReadReq,
+        // TODO: This handling is different from the other APIs here, identify
+        // consistent options for this trait
+        req: &[u8],
         trans: &mut Transaction,
         tw: &mut TLVWriter,
     ) -> Result<(), Error>;

--- a/matter/src/interaction_model/mod.rs
+++ b/matter/src/interaction_model/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use self::{
     core::OpCode,
-    messages::msg::{InvReq, StatusResp, SubscribeReq, WriteReq},
+    messages::msg::{InvReq, StatusResp, WriteReq},
 };
 
 #[derive(PartialEq)]
@@ -70,7 +70,7 @@ pub trait InteractionConsumer {
 
     fn consume_subscribe(
         &self,
-        _req: &SubscribeReq,
+        _req: &[u8],
         _trans: &mut Transaction,
         _tw: &mut TLVWriter,
     ) -> Result<(OpCode, ResponseRequired), Error>;

--- a/matter/src/interaction_model/read.rs
+++ b/matter/src/interaction_model/read.rs
@@ -18,10 +18,8 @@
 use crate::{
     error::Error,
     interaction_model::core::OpCode,
-    tlv::{TLVWriter, TagType},
+    tlv::TLVWriter,
     transport::{packet::Packet, proto_demux::ResponseRequired},
-    utils::writebuf::WriteBuf,
-    wb_shrink, wb_unshrink,
 };
 
 use super::{InteractionModel, Transaction};
@@ -34,20 +32,11 @@ impl InteractionModel {
         proto_tx: &mut Packet,
     ) -> Result<ResponseRequired, Error> {
         proto_tx.set_proto_opcode(OpCode::ReportData as u8);
-        // We have to do these gymnastics because we have to reserve some bytes towards the
-        // end of the slice for adding our terminating TLVs
-        const RESERVE_SIZE: usize = 8;
         let proto_tx_wb = proto_tx.get_writebuf()?;
-        let mut child_wb = wb_shrink!(proto_tx_wb, RESERVE_SIZE);
-        let mut tw = TLVWriter::new(&mut child_wb);
+        let mut tw = TLVWriter::new(proto_tx_wb);
 
-        tw.start_struct(TagType::Anonymous)?;
         self.consumer.consume_read_attr(rx_buf, trans, &mut tw)?;
 
-        //Now that we have everything, start using the proto_tx_wb, by unshrinking it
-        wb_unshrink!(proto_tx_wb, child_wb);
-        let mut tw = TLVWriter::new(proto_tx_wb);
-        tw.end_container()?;
         Ok(ResponseRequired::Yes)
     }
 }

--- a/matter/src/secure_channel/pake.rs
+++ b/matter/src/secure_channel/pake.rs
@@ -115,6 +115,12 @@ impl PaseMgr {
     }
 }
 
+impl Default for PaseMgr {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // This file basically deals with the handlers for the PASE secure channel protocol
 // TLV extraction and encoding is done in this file.
 // We create a Spake2p object and set it up in the exchange-data. This object then

--- a/matter/src/tlv/writer.rs
+++ b/matter/src/tlv/writer.rs
@@ -264,6 +264,10 @@ impl<'a, 'b> TLVWriter<'a, 'b> {
     pub fn rewind_to(&mut self, anchor: usize) {
         self.buf.rewind_tail_to(anchor);
     }
+
+    pub fn get_buf<'c>(&'c mut self) -> &'c mut WriteBuf<'a> {
+        self.buf
+    }
 }
 
 #[cfg(test)]

--- a/matter/src/transport/proto_demux.rs
+++ b/matter/src/transport/proto_demux.rs
@@ -24,7 +24,7 @@ use super::packet::PacketPool;
 
 const MAX_PROTOCOLS: usize = 4;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub enum ResponseRequired {
     Yes,
     No,

--- a/matter/src/utils/writebuf.rs
+++ b/matter/src/utils/writebuf.rs
@@ -18,6 +18,33 @@
 use crate::error::*;
 use byteorder::{ByteOrder, LittleEndian};
 
+/// Shrink WriteBuf
+///
+/// This Macro creates a new (child) WriteBuf which has a truncated slice end.
+/// - It accepts a WriteBuf, and the size to reserve (truncate) towards the end.
+/// - It returns the new (child) WriteBuf
+#[macro_export]
+macro_rules! wb_shrink {
+    ($orig_wb:ident, $reserve:ident) => {{
+        let m_data = $orig_wb.empty_as_mut_slice();
+        let m_wb = WriteBuf::new(m_data, m_data.len() - $reserve);
+        (m_wb)
+    }};
+}
+
+/// Unshrink WriteBuf
+///
+/// This macro unshrinks the WriteBuf
+/// - It accepts the original WriteBuf and the child WriteBuf (that was the result of wb_shrink)
+/// After this call, the child WriteBuf shouldn't be used
+#[macro_export]
+macro_rules! wb_unshrink {
+    ($orig_wb:ident, $new_wb:ident) => {{
+        let m_data_len = $new_wb.as_slice().len();
+        $orig_wb.forward_tail_by(m_data_len);
+    }};
+}
+
 #[derive(Debug)]
 pub struct WriteBuf<'a> {
     buf: &'a mut [u8],

--- a/matter/tests/interaction_model.rs
+++ b/matter/tests/interaction_model.rs
@@ -19,7 +19,6 @@ use boxslab::Slab;
 use matter::error::Error;
 use matter::interaction_model::core::OpCode;
 use matter::interaction_model::messages::msg::InvReq;
-use matter::interaction_model::messages::msg::ReadReq;
 use matter::interaction_model::messages::msg::WriteReq;
 use matter::interaction_model::InteractionConsumer;
 use matter::interaction_model::InteractionModel;
@@ -94,7 +93,7 @@ impl InteractionConsumer for DataModel {
 
     fn consume_read_attr(
         &self,
-        _req: &ReadReq,
+        _req: &[u8],
         _trans: &mut Transaction,
         _tlvwriter: &mut TLVWriter,
     ) -> Result<(), Error> {

--- a/matter/tests/interaction_model.rs
+++ b/matter/tests/interaction_model.rs
@@ -32,6 +32,7 @@ use matter::transport::packet::Packet;
 use matter::transport::packet::PacketPool;
 use matter::transport::proto_demux::HandleProto;
 use matter::transport::proto_demux::ProtoCtx;
+use matter::transport::proto_demux::ResponseRequired;
 use matter::transport::session::SessionMgr;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
@@ -107,6 +108,24 @@ impl InteractionConsumer for DataModel {
         _tlvwriter: &mut TLVWriter,
     ) -> Result<(), Error> {
         Ok(())
+    }
+
+    fn consume_status_report(
+        &self,
+        _req: &matter::interaction_model::messages::msg::StatusResp,
+        _trans: &mut Transaction,
+        _tw: &mut TLVWriter,
+    ) -> Result<(OpCode, ResponseRequired), Error> {
+        Ok((OpCode::StatusResponse, ResponseRequired::No))
+    }
+
+    fn consume_subscribe(
+        &self,
+        _req: &matter::interaction_model::messages::msg::SubscribeReq,
+        _trans: &mut Transaction,
+        _tw: &mut TLVWriter,
+    ) -> Result<(OpCode, matter::transport::proto_demux::ResponseRequired), Error> {
+        Ok((OpCode::StatusResponse, ResponseRequired::No))
     }
 }
 


### PR DESCRIPTION
These are supported by reads as well as subscription. So the following commands work:

```
$ ./out/debug/chip-tool any read-by-id 0xFFFFFFFF 0xFFFFFFFF <node-id> 0xFFFF

$ ./out/debug/chip-tool  any subscribe-by-id 0xFFFFFFFF 0xFFFFFFFF 1 20 <node-id> 0xFFFF

```

The actual notifications from the subscription aren't implemented 