### PR TITLE
Spelling: Sucess => Success

### DIFF
--- a/matter/src/data_model/cluster_on_off.rs
+++ b/matter/src/data_model/cluster_on_off.rs
@@ -90,7 +90,7 @@ impl ClusterType for OnOffCluster {
                         .map_err(|_| IMStatusCode::Failure)?;
                 }
                 cmd_req.trans.complete();
-                Err(IMStatusCode::Sucess)
+                Err(IMStatusCode::Success)
             }
             Commands::On => {
                 cmd_enter!("On");
@@ -105,7 +105,7 @@ impl ClusterType for OnOffCluster {
                 }
 
                 cmd_req.trans.complete();
-                Err(IMStatusCode::Sucess)
+                Err(IMStatusCode::Success)
             }
             Commands::Toggle => {
                 cmd_enter!("Toggle");
@@ -121,7 +121,7 @@ impl ClusterType for OnOffCluster {
                     .write_attribute_raw(Attributes::OnOff as u16, AttrValue::Bool(!value))
                     .map_err(|_| IMStatusCode::Failure)?;
                 cmd_req.trans.complete();
-                Err(IMStatusCode::Sucess)
+                Err(IMStatusCode::Success)
             }
         }
     }

--- a/matter/src/data_model/core/mod.rs
+++ b/matter/src/data_model/core/mod.rs
@@ -135,7 +135,7 @@ impl DataModel {
             encoder.set_path(*path);
             let mut access_req = AccessReq::new(accessor, path, Access::WRITE);
             let r = match Cluster::write_attribute(c, &mut access_req, write_data, &attr) {
-                Ok(_) => IMStatusCode::Sucess,
+                Ok(_) => IMStatusCode::Success,
                 Err(e) => e,
             };
             encoder.encode_status(r, 0);
@@ -384,7 +384,7 @@ impl<'a, 'b, 'c> Encoder for AttrWriteEncoder<'a, 'b, 'c> {
     }
 
     fn encode_status(&mut self, status: IMStatusCode, cluster_status: u16) {
-        if self.skip_error && status != IMStatusCode::Sucess {
+        if self.skip_error && status != IMStatusCode::Success {
             // Don't encode errors
             return;
         }

--- a/matter/src/data_model/objects/cluster.rs
+++ b/matter/src/data_model/objects/cluster.rs
@@ -207,7 +207,7 @@ impl Cluster {
         encoder: &mut dyn Encoder,
         attr: &AttrDetails,
     ) {
-        let mut error = IMStatusCode::Sucess;
+        let mut error = IMStatusCode::Success;
         let base = c.base();
         let a = if let Ok(a) = base.get_attribute(attr.attr_id) {
             a
@@ -225,7 +225,7 @@ impl Cluster {
             error = IMStatusCode::UnsupportedAccess;
         }
 
-        if error != IMStatusCode::Sucess {
+        if error != IMStatusCode::Success {
             encoder.encode_status(error, 0);
         } else if Attribute::is_system_attr(attr.attr_id) {
             c.base().read_system_attribute(encoder, a)

--- a/matter/src/data_model/sdm/admin_commissioning.rs
+++ b/matter/src/data_model/sdm/admin_commissioning.rs
@@ -145,7 +145,7 @@ impl AdminCommCluster {
         let verifier = VerifierData::new(req.verifier.0, req.iterations, req.salt.0);
         self.pase_mgr
             .enable_pase_session(verifier, req.discriminator)?;
-        Err(IMStatusCode::Sucess)
+        Err(IMStatusCode::Success)
     }
 }
 

--- a/matter/src/data_model/sdm/noc.rs
+++ b/matter/src/data_model/sdm/noc.rs
@@ -410,7 +410,7 @@ impl NocCluster {
         }
         cmd_req.trans.complete();
 
-        Err(IMStatusCode::Sucess)
+        Err(IMStatusCode::Success)
     }
 }
 

--- a/matter/src/interaction_model/core.rs
+++ b/matter/src/interaction_model/core.rs
@@ -139,7 +139,7 @@ impl InteractionModel {
         trans.set_timeout(req.timeout.into());
 
         let status = StatusResp {
-            status: IMStatusCode::Sucess,
+            status: IMStatusCode::Success,
         };
         let mut tw = TLVWriter::new(proto_tx.get_writebuf()?);
         let _ = status.to_tlv(&mut tw, TagType::Anonymous);
@@ -213,7 +213,7 @@ impl proto_demux::HandleProto for InteractionModel {
 
 #[derive(FromPrimitive, Debug, Clone, Copy, PartialEq)]
 pub enum IMStatusCode {
-    Sucess = 0,
+    Success = 0,
     Failure = 1,
     InvalidSubscription = 0x7D,
     UnsupportedAccess = 0x7E,

--- a/matter/tests/data_model/acl_and_dataver.rs
+++ b/matter/tests/data_model/acl_and_dataver.rs
@@ -294,7 +294,7 @@ fn wc_write_attribute() {
         peer,
         None,
         input0,
-        &[AttrStatus::new(&ep0_att, IMStatusCode::Sucess, 0)],
+        &[AttrStatus::new(&ep0_att, IMStatusCode::Success, 0)],
     );
     assert_eq!(AttrValue::Uint16(val0), read_cluster_id_write_attr(&im, 0));
     assert_eq!(
@@ -316,8 +316,8 @@ fn wc_write_attribute() {
         None,
         input1,
         &[
-            AttrStatus::new(&ep0_att, IMStatusCode::Sucess, 0),
-            AttrStatus::new(&ep1_att, IMStatusCode::Sucess, 0),
+            AttrStatus::new(&ep0_att, IMStatusCode::Success, 0),
+            AttrStatus::new(&ep1_att, IMStatusCode::Success, 0),
         ],
     );
     assert_eq!(AttrValue::Uint16(val1), read_cluster_id_write_attr(&im, 0));
@@ -350,7 +350,7 @@ fn exact_write_attribute() {
         IMStatusCode::UnsupportedAccess,
         0,
     )];
-    let expected_success = &[AttrStatus::new(&ep0_att, IMStatusCode::Sucess, 0)];
+    let expected_success = &[AttrStatus::new(&ep0_att, IMStatusCode::Success, 0)];
 
     let peer = 98765;
     let mut im = ImEngine::new();
@@ -401,7 +401,7 @@ fn exact_write_attribute_noc_cat() {
         IMStatusCode::UnsupportedAccess,
         0,
     )];
-    let expected_success = &[AttrStatus::new(&ep0_att, IMStatusCode::Sucess, 0)];
+    let expected_success = &[AttrStatus::new(&ep0_att, IMStatusCode::Success, 0)];
 
     let peer = 98765;
     /* CAT in NOC is 1 more, in version, than that in ACL */
@@ -534,8 +534,8 @@ fn write_with_runtime_acl_add() {
         &[input0, acl_input, input0],
         &[
             AttrStatus::new(&ep0_att, IMStatusCode::UnsupportedAccess, 0),
-            AttrStatus::new(&acl_att, IMStatusCode::Sucess, 0),
-            AttrStatus::new(&ep0_att, IMStatusCode::Sucess, 0),
+            AttrStatus::new(&acl_att, IMStatusCode::Success, 0),
+            AttrStatus::new(&ep0_att, IMStatusCode::Success, 0),
         ],
     );
     assert_eq!(AttrValue::Uint16(val0), read_cluster_id_write_attr(&im, 0));
@@ -689,7 +689,7 @@ fn test_write_data_ver() {
         peer,
         None,
         input_correct_dataver,
-        &[AttrStatus::new(&ep0_attwrite, IMStatusCode::Sucess, 0)],
+        &[AttrStatus::new(&ep0_attwrite, IMStatusCode::Success, 0)],
     );
     assert_eq!(AttrValue::Uint16(val0), read_cluster_id_write_attr(&im, 0));
 
@@ -728,7 +728,7 @@ fn test_write_data_ver() {
         peer,
         None,
         input_correct_dataver,
-        &[AttrStatus::new(&ep0_attwrite, IMStatusCode::Sucess, 0)],
+        &[AttrStatus::new(&ep0_attwrite, IMStatusCode::Success, 0)],
     );
     assert_eq!(AttrValue::Uint16(val1), read_cluster_id_write_attr(&im, 0));
 

--- a/matter/tests/data_model/attribute_lists.rs
+++ b/matter/tests/data_model/attribute_lists.rs
@@ -73,7 +73,7 @@ fn attr_list_ops() {
 
     // Test 1: Add Operation - add val0
     let input = &[AttrData::new(None, att_path, EncodeValue::Value(&val0))];
-    let expected = &[AttrStatus::new(&att_data, IMStatusCode::Sucess, 0)];
+    let expected = &[AttrStatus::new(&att_data, IMStatusCode::Success, 0)];
     let _ = handle_write_reqs(input, expected);
 
     {
@@ -83,7 +83,7 @@ fn attr_list_ops() {
 
     // Test 2: Another Add Operation - add val1
     let input = &[AttrData::new(None, att_path, EncodeValue::Value(&val1))];
-    let expected = &[AttrStatus::new(&att_data, IMStatusCode::Sucess, 0)];
+    let expected = &[AttrStatus::new(&att_data, IMStatusCode::Success, 0)];
     let _ = handle_write_reqs(input, expected);
 
     {
@@ -94,7 +94,7 @@ fn attr_list_ops() {
     // Test 3: Edit Operation - edit val1 to val0
     att_path.list_index = Some(Nullable::NotNull(1));
     let input = &[AttrData::new(None, att_path, EncodeValue::Value(&val0))];
-    let expected = &[AttrStatus::new(&att_data, IMStatusCode::Sucess, 0)];
+    let expected = &[AttrStatus::new(&att_data, IMStatusCode::Success, 0)];
     let _ = handle_write_reqs(input, expected);
 
     {
@@ -105,7 +105,7 @@ fn attr_list_ops() {
     // Test 4: Delete Operation - delete index 0
     att_path.list_index = Some(Nullable::NotNull(0));
     let input = &[AttrData::new(None, att_path, delete_item)];
-    let expected = &[AttrStatus::new(&att_data, IMStatusCode::Sucess, 0)];
+    let expected = &[AttrStatus::new(&att_data, IMStatusCode::Success, 0)];
     let _ = handle_write_reqs(input, expected);
 
     {
@@ -121,7 +121,7 @@ fn attr_list_ops() {
         att_path,
         EncodeValue::Value(&overwrite_val),
     )];
-    let expected = &[AttrStatus::new(&att_data, IMStatusCode::Sucess, 0)];
+    let expected = &[AttrStatus::new(&att_data, IMStatusCode::Success, 0)];
     let _ = handle_write_reqs(input, expected);
 
     {
@@ -132,7 +132,7 @@ fn attr_list_ops() {
     // Test 6: Overwrite Operation - delete whole list
     att_path.list_index = None;
     let input = &[AttrData::new(None, att_path, delete_all)];
-    let expected = &[AttrStatus::new(&att_data, IMStatusCode::Sucess, 0)];
+    let expected = &[AttrStatus::new(&att_data, IMStatusCode::Success, 0)];
     let _ = handle_write_reqs(input, expected);
 
     {

--- a/matter/tests/data_model/attributes.rs
+++ b/matter/tests/data_model/attributes.rs
@@ -371,8 +371,8 @@ fn test_write_success() {
         ),
     ];
     let expected = &[
-        AttrStatus::new(&ep0_att, IMStatusCode::Sucess, 0),
-        AttrStatus::new(&ep1_att, IMStatusCode::Sucess, 0),
+        AttrStatus::new(&ep0_att, IMStatusCode::Success, 0),
+        AttrStatus::new(&ep1_att, IMStatusCode::Success, 0),
     ];
 
     let dm = handle_write_reqs(input, expected);
@@ -428,8 +428,8 @@ fn test_write_wc_endpoint() {
         Some(echo_cluster::Attributes::AttWrite as u32),
     );
     let expected = &[
-        AttrStatus::new(&ep0_att, IMStatusCode::Sucess, 0),
-        AttrStatus::new(&ep1_att, IMStatusCode::Sucess, 0),
+        AttrStatus::new(&ep0_att, IMStatusCode::Success, 0),
+        AttrStatus::new(&ep1_att, IMStatusCode::Success, 0),
     ];
 
     let dm = handle_write_reqs(input, expected);

--- a/matter/tests/data_model/commands.rs
+++ b/matter/tests/data_model/commands.rs
@@ -151,7 +151,7 @@ fn test_invoke_cmd_wc_endpoint_only_1_has_cluster() {
     let input = &[cmd_data!(target, 1)];
     let expected = &[ExpectedInvResp::Status(CmdStatus::new(
         expected_path,
-        IMStatusCode::Sucess,
+        IMStatusCode::Success,
         0,
     ))];
     handle_commands(input, expected);

--- a/matter/tests/data_model/timed_requests.rs
+++ b/matter/tests/data_model/timed_requests.rs
@@ -154,8 +154,8 @@ fn test_timed_write_fail_and_success() {
         Some(echo_cluster::Attributes::AttWrite as u32),
     );
     let expected = &[
-        AttrStatus::new(&ep0_att, IMStatusCode::Sucess, 0),
-        AttrStatus::new(&ep1_att, IMStatusCode::Sucess, 0),
+        AttrStatus::new(&ep0_att, IMStatusCode::Success, 0),
+        AttrStatus::new(&ep1_att, IMStatusCode::Success, 0),
     ];
 
     // Test with incorrect handling


### PR DESCRIPTION
This is just fixing a simple spelling mistake.

I also see that you are returning an Err(IMStatusCode::Success), which probably doesn't make sense. Maybe I should create a new PR that removes that from the example.