### PR TITLE
Disable default features on env_logger

### DIFF
--- a/matter/Cargo.toml
+++ b/matter/Cargo.toml
@@ -31,7 +31,7 @@ num = "0.4"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
 log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_debug"] }
-env_logger = "0.10.0"
+env_logger = { version = "0.10.0", default-features = false, features = [] }
 rand = "0.8.5"
 esp-idf-sys = { version = "0.32", features = ["binstart"], optional = true }
 openssl = { git = "https://github.com/sfackler/rust-openssl", optional = true }


### PR DESCRIPTION
The `env_logger` crate is used in tests and examples for logging output. It has default features that rely on `is-terminal`, which relies on `rustix`. `rustix` doesn't compile on the `esp*` targets, and thus using this project on such targets fails.

The simplest solution is to disable the default features.

Relates to #42 