### PR TITLE
modify test_valid_invoke_cmd; proper test case & command type

### DIFF
--- a/matter/tests/interaction_model.rs
+++ b/matter/tests/interaction_model.rs
@@ -40,7 +40,7 @@ use std::sync::{Arc, Mutex};
 struct Node {
     pub endpoint: u16,
     pub cluster: u32,
-    pub command: u16,
+    pub command: u32,
     pub variable: u8,
 }
 
@@ -82,7 +82,7 @@ impl InteractionConsumer for DataModel {
                 let mut common_data = self.node.lock().unwrap();
                 common_data.endpoint = cmd_path_ib.path.endpoint.unwrap_or(1);
                 common_data.cluster = cmd_path_ib.path.cluster.unwrap_or(0);
-                common_data.command = cmd_path_ib.path.leaf.unwrap_or(0) as u16;
+                common_data.command = cmd_path_ib.path.leaf.unwrap_or(0);
                 data.confirm_struct().unwrap();
                 common_data.variable = data.find_tag(0).unwrap().u8().unwrap();
             }
@@ -178,8 +178,9 @@ fn test_valid_invoke_cmd() -> Result<(), Error> {
     // An invoke command for endpoint 0, cluster 49, command 12 and a u8 variable value of 0x05
 
     let b = [
-        0x15, 0x28, 0x00, 0x28, 0x01, 0x36, 0x02, 0x15, 0x37, 0x00, 0x24, 0x00, 0x00, 0x24, 0x01,
-        0x31, 0x24, 0x02, 0x0c, 0x18, 0x35, 0x01, 0x24, 0x00, 0x05, 0x18, 0x18, 0x18, 0x18,
+        0x15, 0x28, 0x00, 0x28, 0x01, 0x36, 0x02, 0x15, 0x37, 0x00, 0x25, 0x00, 0x00, 0x00, 0x26,
+        0x01, 0x31, 0x00, 0x00, 0x00, 0x26, 0x02, 0x0c, 0x00, 0x00, 0x00, 0x18, 0x35, 0x01, 0x24,
+        0x00, 0x05, 0x18, 0x18, 0x18, 0x18,
     ];
 
     let mut out_buf: [u8; 20] = [0; 20];


### PR DESCRIPTION
Hi!
This PR would modify the test case of `test_valid_invoke_cmd()`.

- test case
  - I modified the test case to conform to fit CommandPathIB specs. As shown below:

```
InvokeRequestMessage {                 // TLV Type: Structure (Anonymous)                | 0x15
    SuppressResponse                   // Context Tag 0 Boolean False                    | 0x28 0x00
    TimedRequest                       // Context Tag 1 Boolean False                    | 0x28 0x01
    Array of CommandDataIB [           // Context Tag 2 Array                            | 0x36 0x02        
        CommandDataIB {                // TLV Type: Structure (Anonymous)                | 0x15
            CommandPathIB {            // Context Tag 0 TLV Type: List                   | 0x37 0x00
                Endpoint               // Context Tag 0 Unsigned Int 16 bits, endpoint 0 | 0x25 0x00 0x00 0x00
                Cluster                // Context Tag 1 Unsigned Int 32 bits, cluster 49 | 0x26 0x01 0x31 0x00 0x00 0x00
                Command                // Context Tag 2 Unsigned Int 32 bits, command 12 | 0x26 0x02 0x0c 0x00 0x00 0x00
            }                          // End of Container CommandPathIB                 | 0x18
            CommandFields {            // Context Tag 1 TLV Type: Structure              | 0x35 0x01
                u8                     // Context Tag 0 Unsigned Int 8 bits, value 5     | 0x24 0x00 0x05
            }                          // End of Container CommandFields                 | 0x18
        }                              // End of Container CommandDataIB                 | 0x18
    ]                                  // End of Container Array of CommandDataIB        | 0x18
}                                      // End of Container InvokeRequestMessage          | 0x18
```

- CommandPathIB
  - Command element is unsigned Int 32 bits, so I modified Node command field type to u32.

Thanks.