### PR TITLE
Make RustCrypto work on 32-bit machines

### DIFF
--- a/matter/src/crypto/crypto_rustcrypto.rs
+++ b/matter/src/crypto/crypto_rustcrypto.rs
@@ -155,7 +155,7 @@ impl CryptoKeyPair for KeyPair {
                 let bytes = key.to_bytes();
                 let slice = bytes.as_slice();
                 let len = slice.len();
-                priv_key.copy_from_slice(slice);
+                priv_key[..slice.len()].copy_from_slice(slice);
                 Ok(len)
             }
             KeyType::Public(_) => Err(Error::Crypto),

--- a/matter/src/secure_channel/crypto_rustcrypto.rs
+++ b/matter/src/secure_channel/crypto_rustcrypto.rs
@@ -226,7 +226,7 @@ impl CryptoSpake2 for CryptoRustCrypto {
 
 impl CryptoRustCrypto {
     fn add_to_tt(tt: &mut sha2::Sha256, buf: &[u8]) -> Result<(), Error> {
-        tt.update(buf.len().to_le_bytes());
+        tt.update((buf.len() as u64).to_le_bytes());
         if !buf.is_empty() {
             tt.update(buf);
         }


### PR DESCRIPTION
When using RustCrypto there was a problem on 32-bit machines (e.g. ESP32-C3)

Problem was that `.len()` as used in the hope it's 64bit but `usize` is 32bit on 32-bit systems.

This should fix it
