### PR TITLE
Fix #60

### DIFF
--- a/matter/src/mdns.rs
+++ b/matter/src/mdns.rs
@@ -19,7 +19,7 @@ use core::fmt::Write;
 
 use crate::{data_model::cluster_basic_information::BasicInfoConfig, error::Error};
 
-#[cfg(all(feature = "std", feature = "astro-dnssd"))]
+#[cfg(all(feature = "std", target_os = "macos"))]
 pub mod astro;
 pub mod builtin;
 pub mod proto;
@@ -55,16 +55,16 @@ where
     }
 }
 
-#[cfg(all(feature = "std", feature = "astro-dnssd"))]
+#[cfg(all(feature = "std", target_os = "macos"))]
 pub type DefaultMdns<'a> = astro::Mdns<'a>;
 
-#[cfg(all(feature = "std", feature = "astro-dnssd"))]
+#[cfg(all(feature = "std", target_os = "macos"))]
 pub type DefaultMdnsRunner<'a> = astro::MdnsRunner<'a>;
 
-#[cfg(not(all(feature = "std", feature = "astro-dnssd")))]
+#[cfg(not(all(feature = "std", target_os = "macos")))]
 pub type DefaultMdns<'a> = builtin::Mdns<'a>;
 
-#[cfg(not(all(feature = "std", feature = "astro-dnssd")))]
+#[cfg(not(all(feature = "std", target_os = "macos")))]
 pub type DefaultMdnsRunner<'a> = builtin::MdnsRunner<'a>;
 
 pub struct DummyMdns;


### PR DESCRIPTION
Subject says it all.

I have forgotten a few `[cfg()]`s that were done the old `feature=` based way, before our auto-selection of an mDNS provider based on the underlying OS got active.

Tested on x86 Mac with a Google Controller.