### PR TITLE
fix: add tools/tlv_tool to workspace.exclude

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [workspace]
 members = ["matter", "matter_macro_derive"]
-
-exclude = ["examples/*"]
+exclude = ["examples/*", "tools/tlv_tool"]
 
 # For compatibility with ESP IDF
 [patch.crates-io]


### PR DESCRIPTION
Hi!
This PR would add "tools/tlv_tool" to `workspace.exclude`.

"tools/tlv_tool" has Cargo.toml, but both `workspace.members` and `workspace.exclude` do not contain "tools/tlv_tool" in ./Cargo.toml .
`cd tools/tlv_tool; cargo build --verbose` would fail. So, I would add "tools/tlv_tool" to `workspace.exclude`.