### PR TITLE
modify: Quality bits into separated flags

### DIFF
--- a/rs-matter/src/data_model/cluster_on_off.rs
+++ b/rs-matter/src/data_model/cluster_on_off.rs
@@ -54,7 +54,7 @@ pub const CLUSTER: Cluster<'static> = Cluster {
         Attribute::new(
             AttributesDiscriminants::OnOff as u16,
             Access::RV,
-            Quality::PERSISTENT,
+            Quality::SN,
         ),
     ],
     commands: &[

--- a/rs-matter/src/data_model/objects/attribute.rs
+++ b/rs-matter/src/data_model/objects/attribute.rs
@@ -76,6 +76,8 @@ bitflags! {
         const PERSISTENT = 0x02; // Short: N
         const FIXED = 0x04;      // Short: F
         const NULLABLE = 0x08;   // Short: X
+
+        const SN = Self::SCENE.bits | Self::PERSISTENT.bits;
     }
 }
 

--- a/rs-matter/src/data_model/objects/attribute.rs
+++ b/rs-matter/src/data_model/objects/attribute.rs
@@ -72,10 +72,10 @@ bitflags! {
     #[derive(Default)]
     pub struct Quality: u8 {
         const NONE = 0x00;
-        const SCENE = 0x01;
-        const PERSISTENT = 0x02;
-        const FIXED = 0x03;
-        const NULLABLE = 0x04;
+        const SCENE = 0x01;      // Short: S
+        const PERSISTENT = 0x02; // Short: N
+        const FIXED = 0x04;      // Short: F
+        const NULLABLE = 0x08;   // Short: X
     }
 }
 


### PR DESCRIPTION
Hi!
This PR would modify Quality bits into separated flags. 

For example, Mode Select StandardNamespace Attribute is FX Quality. FX means Fixed and Nullable. 

<img width="75%" alt="スクリーンショット 2023-07-23 19 03 17" src="https://github.com/project-chip/matter-rs/assets/42881635/ac687074-615c-4ceb-a222-ac73dbccb419">

Before the modify, `FIXED` is 0x03. `FIXED` shows 0b11, so it contains `SCENE | PERSISTENT` (= 0b01 | 0b10). I think that Quality bits should be independent of each other.

<img width="75%" alt="スクリーンショット 2023-07-23 18 59 22" src="https://github.com/project-chip/matter-rs/assets/42881635/3865a77e-d5f2-4ebf-8ca8-846c36d5bdff">
