### PR TITLE
mdns: builtin: Fix a typo

### DIFF
--- a/rs-matter/src/mdns/builtin.rs
+++ b/rs-matter/src/mdns/builtin.rs
@@ -230,7 +230,7 @@ impl<'a> MdnsService<'a> {
                                 let len = self.host.broadcast(self, data.buf, 60)?;
 
                                 if len > 0 {
-                                    info!("Broadasting mDNS entry to {}:{}", addr, PORT);
+                                    info!("Broadcasting mDNS entry to {}:{}", addr, PORT);
 
                                     data.chunk = Some(Chunk {
                                         start: 0,


### PR DESCRIPTION
# Purpose #

This PR fixes just a typo.