### PR TITLE
Do not hold on to RefCell borrows across await points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  RUST_TOOLCHAIN: nightly-2023-07-01
+  RUST_TOOLCHAIN: nightly
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CARGO_TERM_COLOR: always
 

--- a/rs-matter/src/mdns/builtin.rs
+++ b/rs-matter/src/mdns/builtin.rs
@@ -208,7 +208,6 @@ impl<'a> MdnsService<'a> {
         select(&mut broadcast, &mut respond).await.unwrap()
     }
 
-    #[allow(clippy::await_holding_refcell_ref)]
     async fn broadcast(&self, tx_pipe: &Pipe<'_>) -> Result<(), Error> {
         loop {
             select(
@@ -258,7 +257,6 @@ impl<'a> MdnsService<'a> {
         }
     }
 
-    #[allow(clippy::await_holding_refcell_ref)]
     async fn respond(&self, rx_pipe: &Pipe<'_>, tx_pipe: &Pipe<'_>) -> Result<(), Error> {
         loop {
             {

--- a/rs-matter/src/secure_channel/crypto_mbedtls.rs
+++ b/rs-matter/src/secure_channel/crypto_mbedtls.rs
@@ -186,7 +186,7 @@ impl CryptoSpake2 {
         let (Z, V) = Self::get_ZV_as_verifier(
             &self.w0,
             &self.L,
-            &mut self.M,
+            &self.M,
             &X,
             &self.xy,
             &self.order,
@@ -228,7 +228,7 @@ impl CryptoSpake2 {
     fn get_ZV_as_prover(
         w0: &Mpi,
         w1: &Mpi,
-        N: &mut EcPoint,
+        N: &EcPoint,
         Y: &EcPoint,
         x: &Mpi,
         order: &Mpi,
@@ -264,7 +264,7 @@ impl CryptoSpake2 {
     fn get_ZV_as_verifier(
         w0: &Mpi,
         L: &EcPoint,
-        M: &mut EcPoint,
+        M: &EcPoint,
         X: &EcPoint,
         y: &Mpi,
         order: &Mpi,
@@ -292,7 +292,7 @@ impl CryptoSpake2 {
         Ok((Z, V))
     }
 
-    fn invert(group: &mut EcGroup, num: &EcPoint) -> Result<EcPoint, mbedtls::Error> {
+    fn invert(group: &EcGroup, num: &EcPoint) -> Result<EcPoint, mbedtls::Error> {
         let p = group.p()?;
         let num_y = num.y()?;
         let inverted_num_y = p.sub(&num_y)?;

--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -397,7 +397,6 @@ impl<'a> Matter<'a> {
     }
 
     #[inline(always)]
-    #[cfg_attr(feature = "nightly", allow(clippy::await_holding_refcell_ref))] // Fine because of the async mutex
     pub async fn handle_exchange<H>(
         &self,
         tx_buf: &mut [u8; MAX_TX_BUF_SIZE],


### PR DESCRIPTION
Subject says it all. We **did** have these cases in `case.rs` and `pake.rs` where I had suppressed the Clippy warnings as I thought I'm smarter than it and these fake, but apparently they weren't.

Code passes unit tests and commissioning with Google.

I also updated the CI to latest Rust nightly (they finally fixed it not to crash), so the nightly build is clean as well.