### PR TITLE
Fix compiler errors about lifetime

### DIFF
--- a/rs-matter/src/mdns/builtin.rs
+++ b/rs-matter/src/mdns/builtin.rs
@@ -127,7 +127,7 @@ impl<'a> MdnsService<'a> {
         buffers: &mut MdnsRunBuffers,
     ) -> Result<(), Error>
     where
-        D: crate::transport::network::NetworkStackDriver,
+        D: crate::transport::network::NetworkStackDriver + 'static,
     {
         let mut udp = crate::transport::udp::UdpListener::new(
             stack,

--- a/rs-matter/src/transport/core.rs
+++ b/rs-matter/src/transport/core.rs
@@ -129,7 +129,7 @@ impl<'a> Matter<'a> {
         handler: &H,
     ) -> Result<(), Error>
     where
-        D: crate::transport::network::NetworkStackDriver,
+        D: crate::transport::network::NetworkStackDriver + 'static,
         H: DataModelHandler,
     {
         let udp = crate::transport::udp::UdpListener::new(


### PR DESCRIPTION
With
```
rustc --version
rustc 1.68.2 (9eb3afe9e 2023-03-27)
cargo --version
cargo 1.68.2 (6feb7c9cf 2023-03-26)
```
I was getting the following errors:
```
   Compiling rs-matter v0.1.0 (/Users/markusbecker/src/matter-rs/rs-matter)
error[E0310]: the parameter type `D` may not live long enough
   --> rs-matter/src/mdns/builtin.rs:131:5
    |
131 | /     {
132 | |         let mut udp = crate::transport::udp::UdpListener::new(
133 | |             stack,
134 | |             crate::transport::network::SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), PORT),
...   |
201 | |             .unwrap()
202 | |     }
    | |_____^ ...so that the type `D` will meet its required lifetime bounds
    |
help: consider adding an explicit lifetime bound...
    |
130 |         D: crate::transport::network::NetworkStackDriver + 'static,
    |                                                          +++++++++

error[E0310]: the parameter type `D` may not live long enough
   --> rs-matter/src/transport/core.rs:134:5
    |
134 | /     {
135 | |         let udp = crate::transport::udp::UdpListener::new(
136 | |             stack,
137 | |             crate::transport::network::SocketAddr::new(
...   |
200 | |             .unwrap()
201 | |     }
    | |_____^ ...so that the type `D` will meet its required lifetime bounds
    |
help: consider adding an explicit lifetime bound...
    |
132 |         D: crate::transport::network::NetworkStackDriver + 'static,
    |                                                          +++++++++

For more information about this error, try `rustc --explain E0310`.
```

This commit applies those recommendations.